### PR TITLE
fix: NixOS compatibility — no /bin/bash, stat builtin breaks lock

### DIFF
--- a/automatic-rename.sh
+++ b/automatic-rename.sh
@@ -135,7 +135,7 @@ ar_lock() {
   fi
   local now mt age
   now=$(date +%s 2>/dev/null || echo 0)
-  mt=$(stat -f %m "$LOCK_DIR" 2>/dev/null || stat -c %Y "$LOCK_DIR" 2>/dev/null || echo "$now")
+  mt=$(stat -c %Y "$LOCK_DIR" 2>/dev/null || stat -f %m "$LOCK_DIR" 2>/dev/null || echo "$now")
   age=$(( now - mt ))
   if [ "$age" -gt 30 ]; then
     rm -f "$LOCK_DIR/owner" 2>/dev/null

--- a/tests/test_fastpath.sh
+++ b/tests/test_fastpath.sh
@@ -54,7 +54,7 @@ fixture procinfo_p1.json <<'JSON'
 {"result":{"process_info":{"foreground_process_group_id":100,
   "foreground_processes":[{"pid":100,"argv0":"-zsh","cmdline":"-zsh"}]}}}
 JSON
-/bin/bash "$ENGINE" preexec "l" shell
+/usr/bin/env bash "$ENGINE" preexec "l" shell
 check "instant function: no rename" "" "$(log)"
 teardown
 
@@ -68,7 +68,7 @@ fixture procinfo_p1.json <<'JSON'
 {"result":{"process_info":{"foreground_process_group_id":200,
   "foreground_processes":[{"pid":200,"argv0":"nvim","cmdline":"nvim README.md"}]}}}
 JSON
-/bin/bash "$ENGINE" preexec "v" shell
+/usr/bin/env bash "$ENGINE" preexec "v" shell
 check "wrapped program: named by foreground" "tab rename t1 [1] nvim" "$(log)"
 teardown
 
@@ -77,7 +77,7 @@ teardown
 # ======================================================================
 setup
 # NOTE: no procinfo_p1.json -> the mock serves "{}" -> no resolvable process.
-/bin/bash "$ENGINE" preexec "l" shell
+/usr/bin/env bash "$ENGINE" preexec "l" shell
 check "sample failure: no rename" "" "$(log)"
 teardown
 
@@ -86,7 +86,7 @@ teardown
 # path must be untouched (renames from the typed word, no process-info call).
 # ======================================================================
 setup
-/bin/bash "$ENGINE" preexec "nvim README.md"
+/usr/bin/env bash "$ENGINE" preexec "nvim README.md"
 check "external command: instant rename" "tab rename t1 [1] nvim" "$(log)"
 teardown
 
@@ -99,7 +99,7 @@ fixture tab_t1.json <<'JSON'
 JSON
 printf '{"t1":{"auto":"nvim","enabled":true}}\n' \
   >"$XDG_STATE_HOME/herdr-automatic-rename/state.json"
-/bin/bash "$ENGINE" precmd zsh
+/usr/bin/env bash "$ENGINE" precmd zsh
 check "precmd: back to shell name" "tab rename t1 [1] zsh" "$(log)"
 teardown
 

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -9,15 +9,15 @@ here=$(cd "$(dirname "$0")" && pwd)
 REPO=$(cd "$here/.." && pwd)
 
 # ---- bash ----
-got=$(HERDR_PANE_ID=x HAL_HOOK="$REPO/shell/hook.bash" /bin/bash -c 'source "$HAL_HOOK"; echo "$_har_bin"')
+got=$(HERDR_PANE_ID=x HAL_HOOK="$REPO/shell/hook.bash" /usr/bin/env bash -c 'source "$HAL_HOOK"; echo "$_har_bin"')
 check "bash: self-locates engine next to hook" "$REPO/automatic-rename.sh" "$got"
 
-got=$(HERDR_PANE_ID=x HAL_HOOK="$REPO/shell/hook.bash" /bin/bash -c \
+got=$(HERDR_PANE_ID=x HAL_HOOK="$REPO/shell/hook.bash" /usr/bin/env bash -c \
   'source "$HAL_HOOK"; source "$HAL_HOOK"; printf "%s\n" "$PROMPT_COMMAND" | grep -c _har_precmd_wrap')
 check "bash: double-source adds PROMPT_COMMAND once" "1" "$got"
 
 # Trap behavior only makes sense in an interactive shell (the only place a hook
-# is sourced). Non-interactive `bash -c` has different DEBUG-trap scoping, so we
+# is sourced). Non-interactive `/usr/bin/env bash -c` has different DEBUG-trap scoping, so we
 # simulate a real .bashrc: set a DEBUG trap, source the hook after it, then run a
 # command. The pre-existing trap must still fire (proof it was not clobbered).
 _rc=$(mktemp "${TMPDIR:-/tmp}/hal-rc.XXXXXX")
@@ -25,15 +25,15 @@ cat >"$_rc" <<EOF
 trap 'echo KEEP_FIRED' DEBUG
 source "$REPO/shell/hook.bash"
 EOF
-got=$(printf 'true\nexit\n' | HERDR_PANE_ID=x /bin/bash --rcfile "$_rc" -i 2>&1)
+got=$(printf 'true\nexit\n' | HERDR_PANE_ID=x /usr/bin/env bash --rcfile "$_rc" -i 2>&1)
 rm -f "$_rc"
 check_contains "bash: never clobbers a pre-existing DEBUG trap" "$got" "KEEP_FIRED"
 
-got=$(HERDR_PANE_ID=x HAL_HOOK="$REPO/shell/hook.bash" /bin/bash -c \
+got=$(HERDR_PANE_ID=x HAL_HOOK="$REPO/shell/hook.bash" /usr/bin/env bash -c \
   'preexec_functions=(); source "$HAL_HOOK"; printf "%s " "${preexec_functions[@]}"')
 check_contains "bash: cooperates with a preexec framework" "$got" "_har_preexec"
 
-got=$(HAL_HOOK="$REPO/shell/hook.bash" /bin/bash -c 'unset HERDR_PANE_ID; source "$HAL_HOOK"; echo "${_har_installed:-unset}"')
+got=$(HAL_HOOK="$REPO/shell/hook.bash" /usr/bin/env bash -c 'unset HERDR_PANE_ID; source "$HAL_HOOK"; echo "${_har_installed:-unset}"')
 check "bash: no-ops outside a herdr pane" "unset" "$got"
 
 # ---- command-word classification (both shells) ----
@@ -46,7 +46,7 @@ clsbox() { # <hook file> -> sets $CLS_SB, $CLS_LOG
   CLS_LOG="$CLS_SB/args.log"; : >"$CLS_LOG"
   mkdir -p "$CLS_SB/shell"
   cp "$REPO/shell/$1" "$CLS_SB/shell/"
-  printf '#!/bin/bash\nprintf "%%s\\n" "$*" >> "%s"\n' "$CLS_LOG" >"$CLS_SB/automatic-rename.sh"
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >> "%s"\n' "$CLS_LOG" >"$CLS_SB/automatic-rename.sh"
   chmod +x "$CLS_SB/automatic-rename.sh"
 }
 clswait() { # poll until the log has 2 lines (or ~1s passes)
@@ -58,7 +58,7 @@ clswait() { # poll until the log has 2 lines (or ~1s passes)
 }
 
 clsbox hook.bash
-HERDR_PANE_ID=x HAL_HOOK="$CLS_SB/shell/hook.bash" /bin/bash -c \
+HERDR_PANE_ID=x HAL_HOOK="$CLS_SB/shell/hook.bash" /usr/bin/env bash -c \
   'source "$HAL_HOOK"; l() { :; }; _har_preexec "l"; _har_preexec "ls -a"; wait' 2>/dev/null
 got=$(clswait)
 check_contains "bash: function word marked shell"     "$got" "preexec l shell"
@@ -80,16 +80,17 @@ else
 fi
 
 # fish classifies with `type --type`, where an external command reads "file".
-# Use /bin/ls (not bare ls): fish wraps ls in a color function, and a function
-# word is exactly what must take the sampled path.
+# Use /usr/bin/env (not bare ls): fish wraps ls in a color function, and a
+# function word is exactly what must take the sampled path. /usr/bin/env is
+# portable across NixOS (no /bin) and standard Linux.
 if command -v fish >/dev/null 2>&1; then
   clsbox hook.fish
   HERDR_PANE_ID=x HAL_HOOK="$CLS_SB/shell/hook.fish" fish -c \
-    'source "$HAL_HOOK"; function l; end; _har_preexec "l"; _har_preexec "/bin/ls -a"' 2>/dev/null
+    'source "$HAL_HOOK"; function l; end; _har_preexec "l"; _har_preexec "/usr/bin/env -a"' 2>/dev/null
   got=$(clswait)
   check_contains "fish: function word marked shell"    "$got" "preexec l shell"
-  check_contains "fish: external command left instant" "$got" "preexec /bin/ls -a"
-  check_absent   "fish: external command not marked"   "$got" "preexec /bin/ls -a shell"
+  check_contains "fish: external command left instant" "$got" "preexec /usr/bin/env -a"
+  check_absent   "fish: external command not marked"   "$got" "preexec /usr/bin/env -a shell"
   rm -rf "$CLS_SB"
 else
   echo "# skip: fish not installed (classification)"

--- a/tests/test_reconcile.sh
+++ b/tests/test_reconcile.sh
@@ -27,7 +27,7 @@ setup() {
   export SHELL_NAME=zsh
 }
 fixture() { cat >"$HERDR_MOCK_DIR/$1"; }   # fixture <name>  (JSON on stdin)
-run_event() { /bin/bash "$ENGINE" "$1"; }
+run_event() { /usr/bin/env bash "$ENGINE" "$1"; }
 log() { cat "$HERDR_MOCK_LOG"; }
 teardown() { rm -rf "$SB" 2>/dev/null || true; }
 

--- a/tests/test_ws_order.sh
+++ b/tests/test_ws_order.sh
@@ -67,7 +67,7 @@ setup() {
 fixture() { cat >"$HERDR_MOCK_DIR/$1"; }
 # collapsed <json-array>  -- write the session file herdr would have persisted.
 collapsed() { printf '{"version":7,"collapsed_space_keys":%s,"workspaces":[]}\n' "$1" >"$SB/session.json"; }
-run_event() { /bin/bash "$ENGINE" "$1"; }
+run_event() { /usr/bin/env bash "$ENGINE" "$1"; }
 log() { cat "$HERDR_MOCK_LOG"; }
 teardown() { rm -rf "$SB" 2>/dev/null || true; }
 


### PR DESCRIPTION
- Replace hardcoded `/bin/bash` with `/usr/bin/env bash` in test
  invocations and mock engine shebangs (NixOS has no /bin).
- Use `/usr/bin/env` instead of `/bin/ls` in fish classification test
  (same reason).
- Swap `stat` fallback order in ar_lock: try `stat -c %Y` (Linux)
  first, fall back to `stat -f %m` (macOS). On NixOS `stat` is a bash
  builtin where `-f %m` parses as file-system mode + a literal `%m`
  filename argument — it exits non-zero but still prints filesystem
  info to stdout, then the fallback appends its own output, producing
  a multiline string that breaks the arithmetic on line 139.

Signed-off-by: Muntasir Mahmud <muntasir.joypurhat@gmail.com>
