### PR TITLE
feat(icons): added icon map to icons.sh and updated naming.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to herdr-automatic-rename are documented here. The format fo
 
 ## [Unreleased]
 
+### Added
+- The icon map moved out of `naming.sh` into `icons.sh` and grew from 9
+- `ICON_FALLBACK` (default `?`): glyph shown when a program is missing from
+- `ICON_MAP`: per-program icon overrides as `("prog=glyph")` pairs, checked
+- - The icon map moved out of `naming.sh` into `icons.sh` and grew from 9 entries to the full `tmux-nerd-font-window-name` map (its [`defaults.yml`](https://raw.githubusercontent.com/joshmedeski/tmux-nerd-font-window-name/main/bin/defaults.yml), ~170 programs), keeping the aliases this plugin always shipped (gvim/view, bun/npx/pnpm, ipython/ipython3, claude/codex/aider)
+- - `ICON_FALLBACK` (default `?`): glyph shown when a program is missing from the map, like upstream's `fallback-icon`. Set it to `''` to turn the fallback off and keep unknown programs text-only. Quick tools on `IGNORED_PROGRAMS` never get an icon either way -- the tab is showing the shell, not the program, so a running `ls` no longer needs to flicker
+- - `ICON_MAP`: per-program icon overrides as `(\"prog=glyph\")` pairs, checked before the builtin map (e.g. `ICON_MAP=(\"claude=󰚩\")`)
 ## [0.2.3] - 2026-08-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,16 @@ All notable changes to herdr-automatic-rename are documented here. The format fo
   before the builtin map (e.g. `ICON_MAP=("claude=󰚩")`).
 - Shell labels get no icon even when the map has them: `precmd` names an idle
   prompt without a program, so a glyph would flip the label between `zsh` and
-  `<glyph> zsh` on every reconcile. This covers the fixed `SHELLS` six and the
-  user's real login shell (`SHELL_NAME`), which can sit outside `SHELLS` (nu,
-  tcsh, elvish, ...), as well as `IGNORED_PROGRAMS` commands showing the shell
-  label.
+  `<glyph> zsh` on every reconcile. This covers the fixed `SHELLS` six,
+  `IGNORED_PROGRAMS` commands showing the shell label, and the user's real
+  login shell (`SHELL_NAME`), which can sit outside `SHELLS` (nu, tcsh,
+  elvish, ...).
+- The login shell is recognized by program, not by computed label: `prog ==
+  SHELL_NAME` is its own shell arm, so a reconcile agrees with the bare prompt
+  even with `SHOW_PROGRAM_ARGS=1` (no `? -elvish` when `SHELL_NAME=elvish`).
+- `HIDE_SHELL` also blanks the login shell itself: with 0.4.0's fixed `SHELLS`
+  six, a login shell outside the list (nu, tcsh, elvish, ...) kept naming
+  itself on reconcile while the idle label stayed blank.
 
 ## [0.4.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,23 @@ All notable changes to herdr-automatic-rename are documented here. The format fo
 ## [Unreleased]
 
 ### Added
+
 - The icon map moved out of `naming.sh` into `icons.sh` and grew from 9
+  entries to the full `tmux-nerd-font-window-name` map (its
+  [`defaults.yml`](https://raw.githubusercontent.com/joshmedeski/tmux-nerd-font-window-name/main/bin/defaults.yml),
+  ~170 programs), keeping the aliases this plugin always shipped (gvim/view,
+  bun/npx/pnpm, ipython/ipython3, claude/codex/aider).
 - `ICON_FALLBACK` (default `?`): glyph shown when a program is missing from
+  the map, like upstream's `fallback-icon`. Set it to `''` to turn the
+  fallback off and keep unknown programs text-only. Quick tools on
+  `IGNORED_PROGRAMS` never get an icon either way -- the tab is showing the
+  shell, not the program, so a running `ls` no longer needs to flicker.
 - `ICON_MAP`: per-program icon overrides as `("prog=glyph")` pairs, checked
-- - The icon map moved out of `naming.sh` into `icons.sh` and grew from 9 entries to the full `tmux-nerd-font-window-name` map (its [`defaults.yml`](https://raw.githubusercontent.com/joshmedeski/tmux-nerd-font-window-name/main/bin/defaults.yml), ~170 programs), keeping the aliases this plugin always shipped (gvim/view, bun/npx/pnpm, ipython/ipython3, claude/codex/aider)
-- - `ICON_FALLBACK` (default `?`): glyph shown when a program is missing from the map, like upstream's `fallback-icon`. Set it to `''` to turn the fallback off and keep unknown programs text-only. Quick tools on `IGNORED_PROGRAMS` never get an icon either way -- the tab is showing the shell, not the program, so a running `ls` no longer needs to flicker
-- - `ICON_MAP`: per-program icon overrides as `(\"prog=glyph\")` pairs, checked before the builtin map (e.g. `ICON_MAP=(\"claude=󰚩\")`)
+  before the builtin map (e.g. `ICON_MAP=("claude=󰚩")`).
+- Shells get no icon even when they match the map: `precmd` names an idle
+  prompt without a program, so giving `zsh` a glyph would make the label flip
+  between `zsh` and `<glyph> zsh` on every reconcile.
+
 ## [0.2.3] - 2026-08-02
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,5 @@ test:
 # per-shell (zsh/fish) so only the portable bash sources are checked.
 lint:
 	@command -v shellcheck >/dev/null 2>&1 \
-		&& shellcheck -s bash automatic-rename.sh naming.sh shell/hook.bash tests/*.sh \
+		&& shellcheck -s bash automatic-rename.sh naming.sh icons.sh shell/hook.bash tests/*.sh \
 		|| echo "shellcheck not installed; skipping"

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Override the path with `HERDR_AUTOMATIC_RENAME_CONFIG`.
 | `SUBSTITUTE_SETS` | two rules | `sed -E` rewrites that tidy up the label, e.g. to shorten a path-heavy command line. |
 | `ICONS_ENABLED` | `0` | `1` prepends a Nerd Font glyph for the program (needs a Nerd Font installed). |
 | `ICON_STYLE` | `name_and_icon` | When icons are on, show `name_and_icon`, `icon` only, or `name` only. |
+| `ICON_FALLBACK` | `?` | Glyph for programs missing from the builtin map (~170 programs, from tmux-nerd-font-window-name's `defaults.yml`). `''` turns the fallback off. |
+| `ICON_MAP` | none | Per-program icon overrides, `("prog=glyph")` pairs; wins over the builtin map. |
 
 `config.example.sh` documents each with examples.
 
@@ -162,7 +164,7 @@ herdr plugin uninstall herdr-automatic-rename
 
 ## Development
 
-Engine: `automatic-rename.sh` (bash 3.2, needs only `jq` and the herdr CLI). Pure naming: `naming.sh`. Tests need only bash and jq:
+Engine: `automatic-rename.sh` (bash 3.2, needs only `jq` and the herdr CLI). Pure naming: `naming.sh` (icons: `icons.sh`). Tests need only bash and jq:
 
 ```sh
 ./tests/run.sh            # all

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Override the path with `HERDR_AUTOMATIC_RENAME_CONFIG`.
 | `SHOW_PROGRAM_ARGS` | `0` | `0` shows just the program name (`git`), `1` shows its full command line (`git log --oneline`). |
 | `MAX_NAME_LEN` | `20` | Cut the finished label off after this many characters. |
 | `SHELL_NAME` | `$SHELL` basename | Label shown at an idle prompt when no program is running (e.g. `zsh`). |
-| `HIDE_SHELL` | `0` | `1` gives a shell tab no name at all, so herdr's own tab number shows there instead of `zsh`. |
+| `HIDE_SHELL` | `0` | `1` gives a shell tab no name at all, so herdr's own tab number shows there instead of `zsh`. Covers the login shell (`SHELL_NAME`), not just the fixed `SHELLS` list. |
 | `SHELLS` | `zsh bash sh fish dash ksh` | Programs counted as "a shell prompt" and shown by their own name. |
 | `NAME_ONLY_PROGRAMS` | editors, git tools, agents | Programs always shown by bare name, never with args (`nvim`, `claude`). |
 | `IGNORED_PROGRAMS` | `ls`, `cd`, `cat`, ... | Quick commands that should not rename the tab. It keeps showing the shell instead. |

--- a/config.example.sh
+++ b/config.example.sh
@@ -56,3 +56,17 @@
 # name_and_icon (default), name, or icon.
 # ICONS_ENABLED=0
 # ICON_STYLE=name_and_icon
+
+# Glyph shown when a program is missing from the builtin map (which comes from
+# tmux-nerd-font-window-name's defaults.yml, ~170 programs). An empty string
+# turns the fallback off, so unknown programs get no icon. Quick tools on
+# IGNORED_PROGRAMS never get an icon either way: the tab is showing the shell,
+# not the program.
+# ICON_FALLBACK='?'
+
+# Per-program icon overrides, "<program>=<glyph>" pairs; wins over the builtin
+# map and the fallback. Glyphs are literal Nerd Font characters.
+# ICON_MAP=(
+#   "claude=󰚩"
+#   "lazygit=󰊢"
+# )

--- a/config.example.sh
+++ b/config.example.sh
@@ -60,8 +60,8 @@
 # Glyph shown when a program is missing from the builtin map (which comes from
 # tmux-nerd-font-window-name's defaults.yml, ~170 programs). An empty string
 # turns the fallback off, so unknown programs get no icon. Quick tools on
-# IGNORED_PROGRAMS never get an icon either way: the tab is showing the shell,
-# not the program.
+# IGNORED_PROGRAMS and shells never get an icon either way: the tab is showing
+# the shell, not the program.
 # ICON_FALLBACK='?'
 
 # Per-program icon overrides, "<program>=<glyph>" pairs; wins over the builtin

--- a/config.example.sh
+++ b/config.example.sh
@@ -29,10 +29,11 @@
 # Name shown at a bare prompt. Defaults to your $SHELL's basename.
 # SHELL_NAME=zsh
 
-# 1 = don't name a shell tab at all: a bare prompt, an explicit shell, and an
-# IGNORED_PROGRAMS command all leave the label empty, and herdr shows its own tab
-# number there instead of "zsh". With AUTO_INDEX=1 the label keeps the jump number
-# alone ("[3]"). Programs are named as usual either way.
+# 1 = don't name a shell tab at all: a bare prompt, an explicit shell, an
+# IGNORED_PROGRAMS command, and the login shell itself (SHELL_NAME, which may be
+# outside the SHELLS list) all leave the label empty, and herdr shows its own
+# tab number there instead of "zsh". With AUTO_INDEX=1 the label keeps the jump
+# number alone ("[3]"). Programs are named as usual either way.
 # HIDE_SHELL=0
 
 # Programs that count as "a shell prompt" and are shown by their own name.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,8 +26,10 @@ skip-if-correct, so re-firing the pass (herdr's own rename re-emits
 `naming.sh` turns `(program, cmdline)` into a display name and touches neither
 herdr nor the filesystem. That keeps the naming rules (shells, name-only
 programs, ignored programs, aliases, substitutions, truncation, icons) unit
-testable in isolation. The engine calls `ar_format` across that seam. Every
-function in both files uses the `ar_` prefix.
+testable in isolation. The icon knobs, glyph map, and lookup live in `icons.sh`
+(sourced by `naming.sh`) so the 100+ arm case statement stays out of the naming
+logic. The engine calls `ar_format` across that seam. Every function in these
+files uses the `ar_` prefix.
 
 ## Why config and state sit at fixed paths
 

--- a/icons.sh
+++ b/icons.sh
@@ -1,0 +1,161 @@
+# icons.sh - Nerd Font glyph map for herdr-automatic-rename, sourced by naming.sh.
+#
+# Pure data + lookup, no herdr or filesystem access, so it stays unit-testable
+# on its own (tests/test_naming.sh sources naming.sh, which pulls this in).
+# Targets bash 3.2 (macOS /bin/bash): no associative arrays, so the builtin map
+# is a case statement, arms sorted by their first program.
+#
+# The map is the `icons:` block of
+#   https://raw.githubusercontent.com/joshmedeski/tmux-nerd-font-window-name/main/bin/defaults.yml
+# (fetched 2026-08-03), plus the aliases this plugin always shipped that the
+# upstream file does not list: gvim/view (vim), bun/npx/pnpm (node),
+# ipython/ipython3 (python), and one glyph for the coding agents
+# claude/codex/aider.
+#
+# The glyphs below are literal Private Use Area characters and render as blank
+# boxes without a Nerd Font installed. They also went missing once: every arm
+# of the old map shipped as `printf ''` from naming.sh's first commit through
+# v0.2.1, which made ICONS_ENABLED=1 a silent no-op (issue #3). Each arm
+# carries its codepoint in a comment so a stripped glyph can be restored, and
+# tests/test_naming.sh asserts the exact bytes, so the same loss fails the
+# suite instead of passing quietly.
+
+# ---- configurable knobs (override in config.sh / $HERDR_AUTOMATIC_RENAME_CONFIG) ----
+: "${ICONS_ENABLED:=0}"       # prepend a Nerd Font glyph (needs a Nerd Font)
+: "${ICON_STYLE:=name_and_icon}"  # name_and_icon (icon+name) | name (name only) | icon (icon only)
+
+# Glyph shown when a program is missing from the map, like upstream's
+# fallback-icon. An EMPTY string turns the fallback off (unknown programs get
+# no icon, as before). The `+x` guard lets config.sh set ICON_FALLBACK=''
+# deliberately; `:=` would silently re-fill it.
+if [ -z "${ICON_FALLBACK+x}" ]; then ICON_FALLBACK='?'; fi
+
+# Per-program icon overrides: "<program>=<glyph>" pairs, checked before the
+# builtin map. Set this in config.sh, e.g. ICON_MAP=("nvim=...").
+declare -p ICON_MAP >/dev/null 2>&1 || ICON_MAP=()
+
+# ar_icon <program> -> a Nerd Font glyph, or $ICON_FALLBACK ("" when disabled).
+# Lookup order: user ICON_MAP override -> builtin map -> fallback. An empty
+# argument returns empty on purpose; ar_format only prepends when the glyph is
+# non-empty, so with the fallback off an unknown program keeps a clean,
+# text-only label.
+ar_icon() {
+  local n=$1 pair
+  [ -n "$n" ] || return 0
+  for pair in "${ICON_MAP[@]}"; do
+    case "$pair" in
+      "$n="*) printf '%s' "${pair#*=}"; return 0 ;;
+    esac
+  done
+  case "$n" in
+    Python|ipython|ipython3|pip|pip3|python|python3) printf '\356\234\274' ;;  # U+E73C
+    R)                                       printf '\357\263\222' ;;  # U+FCD2
+    aider|claude|codex)                      printf '\363\260\232\251' ;;  # U+F06A9
+    alacritty|gnome-terminal|iterm2)         printf '\357\204\240' ;;  # U+F120
+    ansible)                                 printf '\357\227\247' ;;  # U+F5E7
+    ant)                                     printf '\356\235\240' ;;  # U+E760
+    apache2|httpd|nginx)                     printf '\357\202\254' ;;  # U+F0AC
+    apt|dpkg|nala)                           printf '\356\235\275' ;;  # U+E77D
+    atom)                                    printf '\356\235\244' ;;  # U+E764
+    aws)                                     printf '\357\211\260' ;;  # U+F270
+    babel)                                   printf '\356\234\215' ;;  # U+E70D
+    bash|fish|just|nu|tcsh|zsh)              printf '\356\236\225' ;;  # U+E795
+    bat)                                     printf '\363\260\255\237' ;;  # U+F0B5F
+    bazel)                                   printf '\356\230\272' ;;  # U+E63A
+    beam|beam.smp)                           printf '\356\236\261' ;;  # U+E7B1
+    bitbucket)                               printf '\356\234\203' ;;  # U+E703
+    brew)                                    printf '\356\254\251' ;;  # U+EB29
+    btm|btop|glances|htop|mactop|top)        printf '\356\256\242' ;;  # U+EBA2
+    bun|node|npx|pnpm|yarn)                  printf '\356\234\230' ;;  # U+E718
+    caffeinate)                              printf '\357\203\264' ;;  # U+F0F4
+    cargo|rustc|rustup)                      printf '\356\236\250' ;;  # U+E7A8
+    cfdisk|fdisk|parted)                     printf '\357\202\240' ;;  # U+F0A0
+    clang|gcc)                               printf '\356\230\236' ;;  # U+E61E
+    clion|idea|pycharm)                      printf '\356\236\265' ;;  # U+E7B5
+    cmake|julia|make)                        printf '\356\230\244' ;;  # U+E624
+    code|code-insiders)                      printf '\356\236\226' ;;  # U+E796
+    composer)                                printf '\356\236\203' ;;  # U+E783
+    console)                                 printf '\363\260\236\267' ;;  # U+F07B7
+    crontab)                                 printf '\357\201\263' ;;  # U+F073
+    csharp)                                  printf '\356\236\257' ;;  # U+E7AF
+    curl|wget)                               printf '\357\200\231' ;;  # U+F019
+    dart|flutter)                            printf '\356\236\230' ;;  # U+E798
+    deno)                                    printf '\356\255\222' ;;  # U+EB52
+    dnf|yum)                                 printf '\357\214\212' ;;  # U+F30A
+    docker|lazydocker)                       printf '\357\214\210' ;;  # U+F308
+    doctl)                                   printf '\357\222\201' ;;  # U+F481
+    dotnet)                                  printf '\356\235\277' ;;  # U+E77F
+    eclipse)                                 printf '\356\236\260' ;;  # U+E7B0
+    elixir)                                  printf '\356\230\255' ;;  # U+E62D
+    emacs)                                   printf '\356\230\262' ;;  # U+E632
+    firebase)                                printf '\356\236\207' ;;  # U+E787
+    gcloud)                                  printf '\356\211\260' ;;  # U+E270
+    gdb|lldb|valgrind)                       printf '\357\206\210' ;;  # U+F188
+    gh|gitlab|wordpress)                     printf '\356\234\211' ;;  # U+E709
+    ghc|stack)                               printf '\356\235\267' ;;  # U+E777
+    ghostty)                                 printf '\356\273\276' ;;  # U+EEFE
+    git|gitui|lazygit|tig)                   printf '\356\234\202' ;;  # U+E702
+    go)                                      printf '\356\230\247' ;;  # U+E627
+    gpg)                                     printf '\357\202\204' ;;  # U+F084
+    gping|ping)                              printf '\356\234\224' ;;  # U+E714
+    gradle)                                  printf '\356\236\251' ;;  # U+E7A9
+    grunt)                                   printf '\356\230\221' ;;  # U+E611
+    gulp)                                    printf '\356\230\220' ;;  # U+E610
+    gvim|lvim|vi|view|vim)                   printf '\356\230\253' ;;  # U+E62B
+    helm|k9s|kubectl|kubie|minikube)         printf '\363\261\203\276' ;;  # U+F10FE
+    heroku)                                  printf '\356\235\211' ;;  # U+E749
+    hg)                                      printf '\356\234\247' ;;  # U+E727
+    hx)                                      printf '\363\260\224\244' ;;  # U+F0524
+    java)                                    printf '\356\211\226' ;;  # U+E256
+    jekyll)                                  printf '\356\230\260' ;;  # U+E630
+    jenkins)                                 printf '\356\235\247' ;;  # U+E767
+    jest)                                    printf '\356\235\222' ;;  # U+E752
+    jj|lazyjj|svn)                           printf '\356\234\245' ;;  # U+E725
+    laravel)                                 printf '\356\234\277' ;;  # U+E73F
+    lf|lfcd|ranger)                          printf '\357\201\274' ;;  # U+F07C
+    maven)                                   printf '\356\236\264' ;;  # U+E7B4
+    mocha)                                   printf '\356\236\236' ;;  # U+E79E
+    mongo)                                   printf '\356\236\244' ;;  # U+E7A4
+    mysql)                                   printf '\356\234\204' ;;  # U+E704
+    nano)                                    printf '\357\201\200' ;;  # U+F040
+    netbeans)                                printf '\356\235\250' ;;  # U+E768
+    ng)                                      printf '\356\235\223' ;;  # U+E753
+    npm)                                     printf '\356\234\236' ;;  # U+E71E
+    nvim)                                    printf '\356\232\256' ;;  # U+E6AE
+    openssl)                                 printf '\357\200\243' ;;  # U+F023
+    pacman|paru|yay)                         printf '\357\214\203' ;;  # U+F303
+    perl)                                    printf '\356\235\251' ;;  # U+E769
+    php)                                     printf '\356\234\275' ;;  # U+E73D
+    powershell)                              printf '\356\257\207' ;;  # U+EBC7
+    psql)                                    printf '\356\235\256' ;;  # U+E76E
+    puppet)                                  printf '\357\222\231' ;;  # U+F499
+    react)                                   printf '\356\236\272' ;;  # U+E7BA
+    redis)                                   printf '\356\235\255' ;;  # U+E76D
+    rsync)                                   printf '\357\200\241' ;;  # U+F021
+    ruby)                                    printf '\356\210\276' ;;  # U+E23E
+    scala)                                   printf '\356\234\267' ;;  # U+E737
+    scp|ssh)                                 printf '\363\260\243\200' ;;  # U+F08C0
+    screen|tmux)                             printf '\356\257\210' ;;  # U+EBC8
+    sqlite)                                  printf '\357\207\200' ;;  # U+F1C0
+    sublime_text)                            printf '\356\236\252' ;;  # U+E7AA
+    sudo)                                    printf '\357\204\262' ;;  # U+F132
+    swift)                                   printf '\356\235\225' ;;  # U+E755
+    systemctl)                               printf '\357\202\205' ;;  # U+F085
+    terraform)                               printf '\357\262\275' ;;  # U+FCBD
+    tickrs)                                  printf '\356\257\242' ;;  # U+EBE2
+    topgrade)                                printf '\363\260\232\260' ;;  # U+F06B0
+    travis)                                  printf '\356\235\276' ;;  # U+E77E
+    tsc)                                     printf '\356\230\250' ;;  # U+E628
+    unicorn)                                 printf '\363\261\227\203' ;;  # U+F15C3
+    unzip|zip)                               printf '\357\207\206' ;;  # U+F1C6
+    vagrant)                                 printf '\357\212\270' ;;  # U+F2B8
+    virtualbox)                              printf '\356\234\252' ;;  # U+E72A
+    visualstudio)                            printf '\356\234\214' ;;  # U+E70C
+    vue)                                     printf '\357\265\202' ;;  # U+FD42
+    webpack)                                 printf '\356\235\260' ;;  # U+E770
+    weechat)                                 printf '\363\260\255\271' ;;  # U+F0B79
+    yazi)                                    printf '\356\254\271' ;;  # U+EB39
+    zig)                                     printf '\342\206\257' ;;  # U+21AF
+    *) printf '%s' "$ICON_FALLBACK" ;;
+  esac
+}

--- a/naming.sh
+++ b/naming.sh
@@ -113,13 +113,19 @@ ar_format() {
   local prog=$1 cmdline=$2 name="" ic aliased is_shell=0
   aliased=$(ar_alias "$prog")
   if [ -z "$prog" ]; then
-    name=$SHELL_NAME; is_shell=1
+    name=$SHELL_NAME
+    is_shell=1
   elif [ -n "$aliased" ]; then
     name=$aliased # user rename (PROGRAM_ALIASES) wins
   elif ar_in_list "$prog" "${SHELLS[@]}"; then
-    name=$prog; is_shell=1                    # a shell shows its own name (zsh)
+    name=$prog
+    is_shell=1 # a shell shows its own name (zsh)
+  elif [ "$prog" = "$SHELL_NAME" ]; then
+    name=$prog
+    is_shell=1 # the login shell, even outside SHELLS (nu, tcsh, ...)
   elif ar_in_list "$prog" "${IGNORED_PROGRAMS[@]}"; then
-    name=$SHELL_NAME; is_shell=1              # quick tools: keep showing the shell
+    name=$SHELL_NAME
+    is_shell=1 # quick tools: keep showing the shell
   elif ar_in_list "$prog" "${NAME_ONLY_PROGRAMS[@]}"; then
     name="$(ar_subst "$prog")" # nvim, claude, ...: just the name
   elif [ "${SHOW_PROGRAM_ARGS:-1}" = "1" ] && [ -n "$cmdline" ]; then
@@ -130,7 +136,9 @@ ar_format() {
 
   # HIDE_SHELL: drop the shell label entirely and let herdr number the tab. An
   # explicit PROGRAM_ALIASES entry for a shell (e.g. "fish=sh") is a name the
-  # user asked for by hand, so it survives; nothing else about a shell tab does.
+  # user asked for by hand, so it survives; nothing else about a shell tab does
+  # -- bare prompt, an explicit SHELLS entry, an IGNORED_PROGRAMS command, or
+  # the login shell itself.
   if [ "${HIDE_SHELL:-0}" = "1" ] && [ "$is_shell" = "1" ]; then
     printf ''
     return 0
@@ -140,10 +148,10 @@ ar_format() {
   # label is a shell name: precmd names an idle prompt via ar_format "" "",
   # which `[ -n "$prog" ]` denies an icon, so a glyph here would flip the label
   # between "zsh" and "<glyph> zsh" on every reconcile. is_shell covers the
-  # IGNORED_PROGRAMS carve-out and the fixed SHELLS six; comparing against
-  # SHELL_NAME follows the user's real login shell, which is the one the bare
-  # prompt shows -- nu, tcsh, elvish, ... sit outside SHELLS yet still hit the
-  # map, or the fallback, at reconcile.
+  # bare prompt, the fixed SHELLS six, IGNORED_PROGRAMS, and the login shell
+  # itself (SHELL_NAME may sit outside SHELLS -- nu, tcsh, elvish -- yet still
+  # hit the map, or the fallback, at reconcile); comparing against SHELL_NAME
+  # additionally keeps a cmdline- or alias-derived label of the same text plain.
   if [ "${ICONS_ENABLED:-0}" = "1" ] && [ -n "$prog" ] && [ "$is_shell" = "0" ] &&
     [ "$name" != "$SHELL_NAME" ]; then
     ic=$(ar_icon "$prog")
@@ -161,7 +169,7 @@ ar_format() {
       esac
     fi
   fi
-    # Truncate by Unicode codepoint, not byte. bash's ${#name} / ${name:0:$max}
+  # Truncate by Unicode codepoint, not byte. bash's ${#name} / ${name:0:$max}
   # count bytes under a C/POSIX locale (herdr may launch plugins with no LC_*),
   # which would slice a multibyte char in half and emit mojibake. jq (already a
   # hard dependency of this plugin) always reads input as UTF-8, so it slices on

--- a/naming.sh
+++ b/naming.sh
@@ -15,11 +15,18 @@
 # clearing one in config.sh (e.g. IGNORED_PROGRAMS=()) actually takes effect:
 # `${VAR+x}` reports a zero-element array as unset and would overwrite it.
 
+# Icon knobs, the glyph map, and ar_icon live in icons.sh (same directory) so
+# this file stays free of the 100+ entry glyph table. Sourcing it here keeps
+# every caller of naming.sh (automatic-rename.sh and the test suite) working
+# unchanged. icons.sh loads after config.sh has run, so its defaults only fill
+# unset vars.
+_ar_icons_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$_ar_icons_dir/icons.sh"
+unset _ar_icons_dir
+
 # ---- configurable knobs (override in config.sh / $HERDR_AUTOMATIC_RENAME_CONFIG) ----
-: "${MAX_NAME_LEN:=20}"        # truncate the final label to this many chars
-: "${SHOW_PROGRAM_ARGS:=0}"   # 1 = regular programs show their full command line; 0 = name only
-: "${ICONS_ENABLED:=0}"       # prepend a Nerd Font glyph (needs a Nerd Font)
-: "${ICON_STYLE:=name_and_icon}"  # name_and_icon (icon+name) | name (name only) | icon (icon only)
+: "${MAX_NAME_LEN:=20}"     # truncate the final label to this many chars
+: "${SHOW_PROGRAM_ARGS:=0}" # 1 = regular programs show their full command line; 0 = name only
 
 # Name shown at a bare prompt (no foreground program), and while an
 # IGNORED_PROGRAMS command runs, so the tab holds steady instead of flickering.
@@ -65,7 +72,10 @@ ar_alias() {
   [ -n "$n" ] || return 0
   for pair in "${PROGRAM_ALIASES[@]}"; do
     case "$pair" in
-      "$n="*) printf '%s' "${pair#*=}"; return 0 ;;
+    "$n="*)
+      printf '%s' "${pair#*=}"
+      return 0
+      ;;
     esac
   done
 }
@@ -79,33 +89,7 @@ ar_subst() {
   printf '%s' "$s"
 }
 
-# ar_icon <program> -> a Nerd Font glyph, or empty. Edit freely.
-#
-# The glyphs below are literal Private Use Area characters and render as blank
-# boxes without a Nerd Font installed. They also went missing once: every arm
-# shipped as `printf ''` from this file's first commit through v0.2.1, which made
-# ICONS_ENABLED=1 a silent no-op (issue #3). Each arm carries its codepoint in a
-# comment so a stripped glyph can be restored, and tests/test_naming.sh asserts
-# the exact bytes, so the same loss fails the suite instead of passing quietly.
-#
-# An unmatched program returns empty on purpose: ar_format only prepends when the
-# glyph is non-empty, so an unknown program keeps a clean, text-only label.
-ar_icon() {
-  case "$1" in
-    nvim)                             printf '' ;;  # U+E6AE nf-custom-neovim
-    vim|vi|view|gvim)                 printf '' ;;  # U+E62B nf-custom-vim
-    git|lazygit|gitui)                printf '' ;;  # U+E702 nf-dev-git
-    node|npm|npx|yarn|pnpm|deno|bun)  printf '' ;;  # U+E718 nf-dev-nodejs_small
-    python|python3|ipython|ipython3)  printf '' ;;  # U+E73C nf-dev-python
-    docker|lazydocker)                printf '' ;;  # U+F308 nf-linux-docker
-    cargo|rustc|rustup)               printf '' ;;  # U+E7A8 nf-dev-rust
-    go)                               printf '' ;;  # U+E627 nf-seti-go
-    claude|codex|aider)               printf '󰚩' ;;  # U+F06A9 nf-md-robot
-    *) ;;
-  esac
-}
-
-# ar_format <program|""> <cmdline> -> final tab label
+# ---- helpers ----
 #   program == "" means a bare prompt (name by the shell).
 ar_format() {
   local prog=$1 cmdline=$2 name="" ic aliased
@@ -113,26 +97,31 @@ ar_format() {
   if [ -z "$prog" ]; then
     name=$SHELL_NAME
   elif [ -n "$aliased" ]; then
-    name=$aliased                             # user rename (PROGRAM_ALIASES) wins
+    name=$aliased # user rename (PROGRAM_ALIASES) wins
   elif ar_in_list "$prog" "${SHELLS[@]}"; then
-    name=$prog                                # a shell shows its own name (zsh)
+    name=$prog # a shell shows its own name (zsh)
   elif ar_in_list "$prog" "${IGNORED_PROGRAMS[@]}"; then
-    name=$SHELL_NAME                          # quick tools: keep showing the shell
+    name=$SHELL_NAME # quick tools: keep showing the shell
   elif ar_in_list "$prog" "${NAME_ONLY_PROGRAMS[@]}"; then
-    name="$(ar_subst "$prog")"               # nvim, claude, ...: just the name
+    name="$(ar_subst "$prog")" # nvim, claude, ...: just the name
   elif [ "${SHOW_PROGRAM_ARGS:-1}" = "1" ] && [ -n "$cmdline" ]; then
     name="$(ar_subst "$cmdline")"
   else
     name="$(ar_subst "$prog")"
   fi
 
-  if [ "${ICONS_ENABLED:-0}" = "1" ] && [ -n "$prog" ]; then
+  # Icons annotate the program the tab is named after. A program on
+  # IGNORED_PROGRAMS deliberately keeps showing SHELL_NAME (so the tab does not
+  # flicker), so it gets no icon either -- otherwise the fallback would make
+  # every `ls` flash "? zsh". ar_icon itself supplies the fallback glyph.
+  if [ "${ICONS_ENABLED:-0}" = "1" ] && [ -n "$prog" ] &&
+    ! ar_in_list "$prog" "${IGNORED_PROGRAMS[@]}"; then
     ic=$(ar_icon "$prog")
     if [ -n "$ic" ]; then
       case "${ICON_STYLE:-name_and_icon}" in
-        icon)            name=$ic ;;          # icon only
-        name)            : ;;                 # name only (icon suppressed)
-        name_and_icon|*) name="$ic $name" ;;  # icon + name (default)
+      icon) name=$ic ;;                      # icon only
+      name) : ;;                             # name only (icon suppressed)
+      name_and_icon | *) name="$ic $name" ;; # icon + name (default)
       esac
     fi
   fi

--- a/naming.sh
+++ b/naming.sh
@@ -113,9 +113,14 @@ ar_format() {
   # Icons annotate the program the tab is named after. A program on
   # IGNORED_PROGRAMS deliberately keeps showing SHELL_NAME (so the tab does not
   # flicker), so it gets no icon either -- otherwise the fallback would make
-  # every `ls` flash "? zsh". ar_icon itself supplies the fallback glyph.
+  # every `ls` flash "? zsh". Shells get the same treatment for the same
+  # reason: precmd names an idle prompt via ar_format "" "", which `[ -n
+  # "$prog" ]` denies an icon, so a shell glyph here would make the label flip
+  # between "zsh" and "<glyph> zsh" on every reconcile. ar_icon itself supplies
+  # the fallback glyph.
   if [ "${ICONS_ENABLED:-0}" = "1" ] && [ -n "$prog" ] &&
-    ! ar_in_list "$prog" "${IGNORED_PROGRAMS[@]}"; then
+    ! ar_in_list "$prog" "${IGNORED_PROGRAMS[@]}" &&
+    ! ar_in_list "$prog" "${SHELLS[@]}"; then
     ic=$(ar_icon "$prog")
     if [ -n "$ic" ]; then
       case "${ICON_STYLE:-name_and_icon}" in

--- a/tests/test_naming.sh
+++ b/tests/test_naming.sh
@@ -155,17 +155,19 @@ check "idle prompt and shell reconcile agree with icons on" \
   "$(ICONS_ENABLED=1 ar_format '' '')" \
   "$(ICONS_ENABLED=1 ar_format "$SHELL_NAME" '')"
 # SHELL_NAME follows the user's real login shell, which can sit outside the
-# fixed SHELLS six (nu, tcsh, elvish, ...). Reconcile reads the pane leader
-# and would hand such a shell a map glyph, or the fallback, while the idle
-# prompt shows the bare name -- the name comparison suppresses the icon there
-# too, so the two paths still agree.
+# fixed SHELLS six (nu, tcsh, elvish, ...). prog == SHELL_NAME is its own
+# shell arm, so a reconcile reads the bare name (never the cmdline, even with
+# SHOW_PROGRAM_ARGS=1 -- "-elvish" would dodge a name-based comparison) and
+# gets no glyph or fallback, keeping it equal to the idle prompt.
 check "odd login shell (elvish) gets no icon" "elvish" \
   "$(SHELL_NAME=elvish ICONS_ENABLED=1 ar_format 'elvish' '')"
 check "odd login shell outside map (nu) -> no fallback glyph" "nu" \
   "$(SHELL_NAME=nu ICONS_ENABLED=1 ar_format 'nu' '')"
-check "idle and odd-shell reconcile agree" \
-  "$(SHELL_NAME=elvish ICONS_ENABLED=1 ar_format '' '')" \
-  "$(SHELL_NAME=elvish ICONS_ENABLED=1 ar_format 'elvish' '')"
+check "odd login shell with args on -> shell name, no icon" "elvish" \
+  "$(SHELL_NAME=elvish ICONS_ENABLED=1 SHOW_PROGRAM_ARGS=1 ar_format 'elvish' '-elvish')"
+check "idle and odd-shell reconcile agree with args on" \
+  "$(SHELL_NAME=elvish ICONS_ENABLED=1 SHOW_PROGRAM_ARGS=1 ar_format '' '')" \
+  "$(SHELL_NAME=elvish ICONS_ENABLED=1 SHOW_PROGRAM_ARGS=1 ar_format 'elvish' '-elvish')"
 # Under ICON_STYLE=icon a lone fallback glyph would be the whole label, so it
 # is suppressed and the plain name kept; name_and_icon still shows "? name"
 # (pinned above).
@@ -191,6 +193,11 @@ check "hide_shell bare prompt" "" "$(HIDE_SHELL=1 ar_format '' '')"
 check "hide_shell explicit fish" "" "$(HIDE_SHELL=1 ar_format 'fish' '-fish')"
 check "hide_shell explicit bash" "" "$(HIDE_SHELL=1 ar_format 'bash' 'bash')"
 check "hide_shell ignored ls" "" "$(HIDE_SHELL=1 ar_format 'ls' 'ls -la')"
+# The login shell is hidden too, even outside SHELLS and with args on: without
+# the prog == SHELL_NAME arm, "nu" would name itself on reconcile while the
+# idle prompt stays blank (the HIDE_SHELL gap from the 0.4.0 release).
+check "hide_shell login shell outside SHELLS (nu)" "" \
+  "$(SHELL_NAME=nu HIDE_SHELL=1 SHOW_PROGRAM_ARGS=1 ar_format 'nu' '-nu')"
 # Only shells are hidden: a real program is named exactly as before.
 check "hide_shell keeps nvim" "nvim" "$(HIDE_SHELL=1 ar_format 'nvim' 'nvim README.md')"
 check "hide_shell keeps program" "htop" "$(HIDE_SHELL=1 SHOW_PROGRAM_ARGS=0 ar_format 'htop' 'htop -d 5')"

--- a/tests/test_naming.sh
+++ b/tests/test_naming.sh
@@ -122,6 +122,18 @@ check "icons on, unknown -> fallback glyph + name" "? nosuchprog" \
 # even though sudo has a real glyph in the map and ls would hit the fallback.
 check "icons on, ignored program -> shell name, no icon" "zsh" \
   "$(ICONS_ENABLED=1 ar_format 'sudo' 'sudo apt update')"
+# Shells get no icon even when the map knows them (zsh is in icons.sh, dash is
+# not): precmd names an idle prompt via ar_format "" "", which `[ -n "$prog" ]`
+# denies an icon, so a shell glyph here would flip the label between "zsh" and
+# "<glyph> zsh" on every reconcile. The last check pins both paths to the same
+# string.
+check "icons on, shell program -> shell name, no icon" "zsh" \
+  "$(ICONS_ENABLED=1 ar_format 'zsh' '-zsh')"
+check "icons on, shell missing from map -> no fallback glyph" "dash" \
+  "$(ICONS_ENABLED=1 ar_format 'dash' '')"
+check "idle prompt and shell reconcile agree with icons on" \
+  "$(ICONS_ENABLED=1 ar_format '' '')" \
+  "$(ICONS_ENABLED=1 ar_format "$SHELL_NAME" '')"
 # ICON_MAP works end to end through ar_format.
 check "ICON_MAP override end to end" "$g_agent nosuchprog" \
   "$(

--- a/tests/test_naming.sh
+++ b/tests/test_naming.sh
@@ -10,14 +10,14 @@ SHELL_NAME=zsh
 . "$here/../naming.sh"
 
 # ---- bare prompt / shells ----
-check "bare prompt -> shell name"      "zsh"  "$(ar_format '' '')"
-check "explicit shell shows own name"  "bash" "$(ar_format 'bash' 'bash')"
-check "fish shell name"                "fish" "$(ar_format 'fish' '')"
+check "bare prompt -> shell name" "zsh" "$(ar_format '' '')"
+check "explicit shell shows own name" "bash" "$(ar_format 'bash' 'bash')"
+check "fish shell name" "fish" "$(ar_format 'fish' '')"
 
 # ---- name-only programs (editors, agents, git) ----
-check "nvim is name-only"    "nvim"   "$(ar_format 'nvim' 'nvim README.md')"
-check "claude is name-only"  "claude" "$(ar_format 'claude' 'claude --dangerously-skip-permissions')"
-check "git is name-only"     "git"    "$(ar_format 'git' 'git status')"
+check "nvim is name-only" "nvim" "$(ar_format 'nvim' 'nvim README.md')"
+check "claude is name-only" "claude" "$(ar_format 'claude' 'claude --dangerously-skip-permissions')"
+check "git is name-only" "git" "$(ar_format 'git' 'git status')"
 
 # ---- ignored programs keep showing the shell ----
 check "ls is ignored -> shell" "zsh" "$(ar_format 'ls' 'ls -la')"
@@ -25,18 +25,18 @@ check "cd is ignored -> shell" "zsh" "$(ar_format 'cd' 'cd ..')"
 
 # ---- regular programs show their command line (SHOW_PROGRAM_ARGS default on) ----
 SHOW_PROGRAM_ARGS=1
-check "regular program shows cmdline"   "htop -d 5"    "$(ar_format 'htop' 'htop -d 5')"
+check "regular program shows cmdline" "htop -d 5" "$(ar_format 'htop' 'htop -d 5')"
 check "regular program, args off -> name only" "psql" "$(SHOW_PROGRAM_ARGS=0 ar_format 'psql' 'psql -h db')"
 
 # ---- program aliases win over category ----
 PROGRAM_ALIASES=("clx=hn" "lazygit=lg")
-check "alias clx->hn"       "hn" "$(ar_format 'clx' 'clx --nerdfonts')"
-check "alias lazygit->lg"   "lg" "$(ar_format 'lazygit' 'lazygit')"
+check "alias clx->hn" "hn" "$(ar_format 'clx' 'clx --nerdfonts')"
+check "alias lazygit->lg" "lg" "$(ar_format 'lazygit' 'lazygit')"
 PROGRAM_ALIASES=()
 
 # ---- substitutions ----
-check "poetry shell -> poetry" "poetry"   "$(ar_format 'poetry' 'poetry shell')"
-check "ipython3 collapse"      "ipython3" "$(ar_format 'ipython3' '/usr/bin/ipython3')"
+check "poetry shell -> poetry" "poetry" "$(ar_format 'poetry' 'poetry shell')"
+check "ipython3 collapse" "ipython3" "$(ar_format 'ipython3' '/usr/bin/ipython3')"
 
 # ---- truncation (MAX_NAME_LEN), counted by codepoint ----
 check "truncates to MAX_NAME_LEN" "12345678901234567890" \
@@ -49,39 +49,56 @@ check "multibyte truncation is clean" "ünïcödé" \
 # Expected glyphs are built from explicit UTF-8 byte escapes rather than pasted
 # literals: bash 3.2 has no $'\uXXXX', and the Private Use Area codepoints these
 # tests assert on are precisely what an editor or a copy-paste silently ate once
-# before (ar_icon shipped with every arm returning "", so ICONS_ENABLED was a
-# no-op through v0.2.1). Byte escapes cannot be eaten that way, so these tests
-# still fail loudly if the glyphs ever vanish from naming.sh again.
-g_nvim=$(printf '\xee\x9a\xae')    # U+E6AE nf-custom-neovim
-g_vim=$(printf '\xee\x98\xab')     # U+E62B nf-custom-vim
-g_git=$(printf '\xee\x9c\x82')     # U+E702 nf-dev-git
-g_node=$(printf '\xee\x9c\x98')    # U+E718 nf-dev-nodejs_small
-g_python=$(printf '\xee\x9c\xbc')  # U+E73C nf-dev-python
-g_docker=$(printf '\xef\x8c\x88')  # U+F308 nf-linux-docker
-g_cargo=$(printf '\xee\x9e\xa8')   # U+E7A8 nf-dev-rust
-g_go=$(printf '\xee\x98\xa7')      # U+E627 nf-seti-go
-g_agent=$(printf '\xf3\xb0\x9a\xa9')  # U+F06A9 nf-md-robot
+# before (the old ar_icon shipped with every arm returning "", so ICONS_ENABLED
+# was a no-op through v0.2.1). Byte escapes cannot be eaten that way, so these
+# tests still fail loudly if the glyphs ever vanish from icons.sh again.
+g_nvim=$(printf '\xee\x9a\xae')      # U+E6AE nf-custom-neovim
+g_vim=$(printf '\xee\x98\xab')       # U+E62B nf-custom-vim
+g_git=$(printf '\xee\x9c\x82')       # U+E702 nf-dev-git
+g_node=$(printf '\xee\x9c\x98')      # U+E718 nf-dev-nodejs_small
+g_python=$(printf '\xee\x9c\xbc')    # U+E73C nf-dev-python
+g_docker=$(printf '\xef\x8c\x88')    # U+F308 nf-linux-docker
+g_cargo=$(printf '\xee\x9e\xa8')     # U+E7A8 nf-dev-rust
+g_go=$(printf '\xee\x98\xa7')        # U+E627 nf-seti-go
+g_agent=$(printf '\xf3\xb0\x9a\xa9') # U+F06A9 nf-md-robot
+g_htop=$(printf '\xee\xae\xa2')      # U+EBA2
 
 # ar_icon must return a real glyph per program group, not the empty string.
-check "ar_icon nvim"   "$g_nvim"   "$(ar_icon nvim)"
-check "ar_icon vim"    "$g_vim"    "$(ar_icon vim)"
-check "ar_icon gvim"   "$g_vim"    "$(ar_icon gvim)"
-check "ar_icon git"    "$g_git"    "$(ar_icon git)"
-check "ar_icon lazygit" "$g_git"   "$(ar_icon lazygit)"
-check "ar_icon node"   "$g_node"   "$(ar_icon node)"
-check "ar_icon pnpm"   "$g_node"   "$(ar_icon pnpm)"
+check "ar_icon nvim" "$g_nvim" "$(ar_icon nvim)"
+check "ar_icon vim" "$g_vim" "$(ar_icon vim)"
+check "ar_icon gvim" "$g_vim" "$(ar_icon gvim)"
+check "ar_icon git" "$g_git" "$(ar_icon git)"
+check "ar_icon lazygit" "$g_git" "$(ar_icon lazygit)"
+check "ar_icon node" "$g_node" "$(ar_icon node)"
+check "ar_icon pnpm" "$g_node" "$(ar_icon pnpm)"
 check "ar_icon python3" "$g_python" "$(ar_icon python3)"
 check "ar_icon docker" "$g_docker" "$(ar_icon docker)"
-check "ar_icon cargo"  "$g_cargo"  "$(ar_icon cargo)"
-check "ar_icon go"     "$g_go"     "$(ar_icon go)"
-check "ar_icon claude" "$g_agent"  "$(ar_icon claude)"
-check "ar_icon codex"  "$g_agent"  "$(ar_icon codex)"
+check "ar_icon cargo" "$g_cargo" "$(ar_icon cargo)"
+check "ar_icon go" "$g_go" "$(ar_icon go)"
+check "ar_icon claude" "$g_agent" "$(ar_icon claude)"
+check "ar_icon codex" "$g_agent" "$(ar_icon codex)"
+# htop used to be the "unknown program" sentinel; the upstream map knows it.
+check "ar_icon htop" "$g_htop" "$(ar_icon htop)"
 
-# An unknown program has no glyph. This is the documented contract ("or empty")
-# and it is what keeps the `[ -n "$ic" ]` guard in ar_format meaningful, so it
-# must stay empty rather than gaining a fallback icon.
-check "ar_icon unknown -> empty" "" "$(ar_icon htop)"
+# A program missing from the map gets the fallback glyph by default; an empty
+# ICON_FALLBACK turns that off and restores the old empty-returning contract.
+check "ar_icon unknown -> fallback" "?" "$(ar_icon nosuchprog)"
+check "ar_icon unknown, fallback off -> empty" "" "$(ICON_FALLBACK='' ar_icon nosuchprog)"
+# The fallback must never apply to the empty argument (ar_format only asks for
+# a real program; ar_icon '' is a guard, not a lookup).
 check "ar_icon empty arg -> empty" "" "$(ar_icon '')"
+
+# ICON_MAP overrides win over both the builtin map and the fallback. (Arrays
+# cannot be passed as a command prefix -- bash exports them as a flat string --
+# so the assignment is a separate statement before the call, as elsewhere.)
+check "ICON_MAP overrides builtin glyph" "$g_vim" "$(
+  ICON_MAP=("nvim=${g_vim}")
+  ar_icon nvim
+)"
+check "ICON_MAP covers unknown program" "$g_agent" "$(
+  ICON_MAP=("nosuchprog=${g_agent}")
+  ar_icon nosuchprog
+)"
 
 # ICON_STYLE wiring, end to end through ar_format.
 check "icon style default is icon+name" "$g_nvim nvim" \
@@ -95,9 +112,22 @@ check "icon style 'name' suppresses glyph" "nvim" \
 
 # Icons off (the default) never prepends a glyph, even for a known program.
 check "icons off -> no glyph" "nvim" "$(ar_format 'nvim' 'nvim')"
-# A program with no glyph keeps its plain name even with icons on.
-check "icons on, unknown program -> plain name" "htop" \
-  "$(ICONS_ENABLED=1 SHOW_PROGRAM_ARGS=0 ar_format 'htop' 'htop -d 5')"
+# Unknown program with icons on and the fallback off: plain name, no glyph.
+check "icons on, fallback off, unknown -> plain name" "nosuchprog" \
+  "$(ICONS_ENABLED=1 ICON_FALLBACK='' SHOW_PROGRAM_ARGS=0 ar_format 'nosuchprog' 'nosuchprog -d 5')"
+# Unknown program with icons on: fallback glyph + name.
+check "icons on, unknown -> fallback glyph + name" "? nosuchprog" \
+  "$(ICONS_ENABLED=1 SHOW_PROGRAM_ARGS=0 ar_format 'nosuchprog' 'nosuchprog -d 5')"
+# An ignored program keeps showing the shell, so it gets no icon either --
+# even though sudo has a real glyph in the map and ls would hit the fallback.
+check "icons on, ignored program -> shell name, no icon" "zsh" \
+  "$(ICONS_ENABLED=1 ar_format 'sudo' 'sudo apt update')"
+# ICON_MAP works end to end through ar_format.
+check "ICON_MAP override end to end" "$g_agent nosuchprog" \
+  "$(
+    ICON_MAP=("nosuchprog=${g_agent}")
+    ICONS_ENABLED=1 SHOW_PROGRAM_ARGS=0 ar_format 'nosuchprog' 'nosuchprog -x'
+  )"
 
 # A glyph is one codepoint, so "<glyph> <name>" must be truncated by codepoint,
 # never mid-byte. node is not name-only, so its cmdline is long enough to cut:


### PR DESCRIPTION
- sourced icons.sh in naming.sh to provide glyph lookup without associative arrays.
- added ICON_FALLBACK var with default '?' to display fallback glyph for unknown programs.
- added ICON_MAP var for per-program glyph overrides, checked before builtin map.
- updated README and architecture docs to describe new icon map and configuration options.
- extended test suite to verify naming.sh loads icons.sh correctly.
