### PR TITLE
fix(naming): name an agent behind a runtime after the agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ All notable changes to herdr-automatic-rename are documented here. The format fo
 
 ## [Unreleased]
 
+### Fixed
+
+- An agent whose entrypoint is an interpreted script named its tab after the
+  interpreter. An npm bin shim is a JS file behind a node shebang, so the kernel
+  execs the runtime and the pane's foreground process is `node` on every
+  platform: a codex pane read `node`. Before 0.2.3 the same pane read
+  `MainThread` -- the resolution chain then had no argv[0] step, so a Linux
+  pane (no argv0) fell through to the process's `name`, which for node is its
+  thread name; the #6 fix moved these tabs from `MainThread` to `node`. A pip
+  or pipx installed agent hits the same thing through `python`, its console
+  script being a shebang file too. (An agent whose package ships or execs a
+  native binary -- claude, opencode -- reports its own name and was never
+  affected.)
+
+  Where the foreground program is a language runtime or package runner (the new
+  `WRAPPER_PROGRAMS` list) and herdr has detected an agent in that pane, herdr's
+  answer is used instead and the tab reads `codex`. The agent is read off the
+  pane objects the reconcile already holds -- herdr publishes its detection
+  result on the pane itself -- so the lookup costs no extra herdr call on any
+  version.
+
+  Both conditions are required, so a plain `node server.js` tab keeps its name,
+  and an agent that reports its own name never consults the pane's agent field.
+  Identification stays herdr's job on purpose: its detector already unwraps
+  runtime-fronted agents, so a pane it cannot identify is an upstream detection
+  gap, not something this plugin second-guesses from `argv`.
+
 ## [0.6.0] - 2026-08-13
 
 Splits the `[N]` jump-key numbering by item kind. `AUTO_INDEX_WORKSPACES`,

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Override the path with `HERDR_AUTOMATIC_RENAME_CONFIG`.
 | `SHELLS` | `zsh bash sh fish dash ksh` | Programs counted as "a shell prompt" and shown by their own name. |
 | `NAME_ONLY_PROGRAMS` | editors, git tools, agents | Programs always shown by bare name, never with args (`nvim`, `claude`). |
 | `IGNORED_PROGRAMS` | `ls`, `cd`, `cat`, ... | Quick commands that should not rename the tab. It keeps showing the shell instead. |
+| `WRAPPER_PROGRAMS` | `node`, `npx`, `bun`, `python`, ... | Language runtimes and package runners that front for the program you launched. In a pane herdr has detected an agent in, the tab is named after that agent instead of the runtime. |
 | `PROGRAM_ALIASES` | none | Force a specific program to a custom label, e.g. `("lazygit=lg")`. |
 | `SUBSTITUTE_SETS` | two rules | `sed -E` rewrites that tidy up the label, e.g. to shorten a path-heavy command line. |
 | `ICONS_ENABLED` | `0` | `1` prepends a Nerd Font glyph for the program (needs a Nerd Font installed). Shell labels never get one, so the tab doesn't flicker between `zsh` and `<glyph> zsh`. |

--- a/automatic-rename.sh
+++ b/automatic-rename.sh
@@ -350,6 +350,23 @@ ar_resolve_pane() {
   ' 2>/dev/null
 }
 
+# ar_pane_agent_kind <pane_id> -> the agent herdr detected in that pane, or "".
+# herdr publishes its detection result on the pane object itself (.agent), so
+# this reads the AR_PANES_JSON the reconcile already fetched -- no extra herdr
+# call on any version. The panes carrying .agent are exactly the ones
+# `agent list` reports (verified against a live herdr 0.8.0). The neighboring
+# .agent_session is deliberately NOT consulted: it is a resume reference, and a
+# pane can carry one while detection reports nothing (herdr#803's half-wired
+# state), so naming from it would bypass the detection gate on a stale ref.
+ar_pane_agent_kind() {
+  printf '%s' "$AR_PANES_JSON" | jq -r --arg p "$1" '
+    (.result.panes // .panes // [])
+    | map(select(.pane_id == $p))
+    | .[0]
+    | if . == null then "" else (.agent // "") end
+  ' 2>/dev/null
+}
+
 # ar_pane_program <pane_id> -> TSV "program<TAB>cmdline".
 # The foreground command is the process-group leader (pid == group id). At a bare
 # prompt the leader IS the login shell, whose argv0 ("-zsh") strips to "zsh".
@@ -385,7 +402,7 @@ ar_pane_program() {
 # failure); a successful HIDE_SHELL computation returns 0 with EMPTY output, so
 # the caller must read the status, not the string, to tell the two apart.
 ar_tab_name() {
-  local pane info prog="" cmd=""
+  local pane info prog="" cmd="" kind=""
   pane=$(ar_resolve_pane "$1" "$2" "$3")
   [ -n "$pane" ] || return 1
   # process-info can fail transiently (pane closing, socket hiccup) or resolve no
@@ -395,6 +412,19 @@ ar_tab_name() {
   info=$(ar_pane_program "$pane") || return 1
   IFS=$'\t' read -r prog cmd <<< "$info"
   [ -n "$prog" ] || return 1
+  # An agent installed through npm or npx fronts as its runtime, so the tab would
+  # be named "node" for a pane herdr knows is running codex. Where the foreground
+  # program is one of those runtimes AND herdr reports an agent for the pane, its
+  # answer wins. Both conditions are needed: a plain `node server.js` tab has no
+  # agent and keeps its name, and an agent that reports its own name never
+  # reaches this.
+  if ar_in_list "$prog" "${WRAPPER_PROGRAMS[@]}"; then
+    kind=$(ar_pane_agent_kind "$pane")
+    if [ -n "$kind" ]; then
+      prog=$kind
+      cmd=$kind
+    fi
+  fi
   ar_format "$prog" "$cmd"
 }
 

--- a/config.example.sh
+++ b/config.example.sh
@@ -69,6 +69,16 @@
 # keeps showing the shell so it does not flicker.
 # IGNORED_PROGRAMS=(ls eza ll la cd z zoxide cat bat less more echo pwd clear which man head tail wc cp mv rm mkdir touch fzf sudo doas)
 
+# Language runtimes and package runners that front for the program you actually
+# launched. An agent installed from npm is usually a bin shim pointing at a JS
+# entrypoint, so the foreground process is `node` and the tab would be named
+# after the runtime; pip and pipx console scripts do the same through `python`.
+# When one of these is the foreground program in a pane herdr has detected an
+# agent in, the tab is named after that agent instead ("codex", not "node").
+# Both conditions are needed, so a plain `node server.js` tab keeps its name.
+# Add your interpreter here if it resolves to a versioned name (python3.12).
+# WRAPPER_PROGRAMS=(node bun deno npx bunx npm pnpm yarn python python3 uv uvx pipx ruby)
+
 # Rename specific programs on the tab. "<program>=<label>" pairs; wins over every
 # rule except the bare-prompt shell name.
 # PROGRAM_ALIASES=(

--- a/naming.sh
+++ b/naming.sh
@@ -60,6 +60,19 @@ declare -p NAME_ONLY_PROGRAMS >/dev/null 2>&1 || NAME_ONLY_PROGRAMS=(nvim vim vi
 # keeps showing the shell (SHELL_NAME) so it does not flicker.
 declare -p IGNORED_PROGRAMS >/dev/null 2>&1 || IGNORED_PROGRAMS=(ls eza ll la cd z zoxide cat bat less more echo pwd clear which man head tail wc cp mv rm mkdir touch fzf sudo doas)
 
+# Language runtimes and package runners that front for the program you actually
+# launched. An agent installed from npm is usually a bin shim pointing at a JS
+# entrypoint: the kernel execs the interpreter, so the foreground process is
+# node and the tab would be named after it. A pip or pipx console script is the
+# same story for python. (An agent whose package ships or execs a native binary
+# -- claude, opencode -- reports its own name and never needs this.)
+#
+# Where herdr has detected an agent in that pane, its answer is used instead (see
+# ar_tab_name). Everywhere else these are named as any other program, so a plain
+# `node server.js` tab is untouched.
+declare -p WRAPPER_PROGRAMS >/dev/null 2>&1 || WRAPPER_PROGRAMS=(node bun deno npx bunx npm pnpm yarn
+  python python3 uv uvx pipx ruby)
+
 # Ordered, complete `sed -E` programs applied to the final display string.
 declare -p SUBSTITUTE_SETS >/dev/null 2>&1 || SUBSTITUTE_SETS=(
   's|.*ipython([32])|ipython\1|'

--- a/tests/test_reconcile.sh
+++ b/tests/test_reconcile.sh
@@ -657,4 +657,75 @@ check_absent   "non-digit bracket survives"    "$out" "workspace rename w2"
 check_absent   "unnamed kind still untouched"  "$out" "agent rename"
 teardown
 
+# ======================================================================
+# Scenario 19: an agent behind a language runtime.
+#
+# An agent installed through npm or npx runs as its runtime (its bin shim is a
+# JS file behind a node shebang), so a codex pane was named "node". herdr
+# detects the agent regardless and publishes it on the pane object, and where
+# the foreground program is a runtime that answer wins. No agents.json fixture:
+# the name must come from the pane fields alone, with no `agent list` call.
+#
+# Both halves are required, and the scenario pins each: t2 is an ordinary node
+# program with no agent in the pane and keeps its name, t3 is an agent that
+# reports itself and is unaffected. t4 pins the gate itself: its pane carries
+# only an agent_session (a resume ref -- herdr#803's half-wired state, where
+# detection reports nothing and agent list excludes the pane), which must NOT
+# name the tab.
+# ======================================================================
+setup
+export NAME_TABS=1 AUTO_INDEX=1
+fixture workspaces.json <<'JSON'
+{"result":{"workspaces":[{"workspace_id":"w1","label":"api"}]}}
+JSON
+fixture tabs_w1.json <<'JSON'
+{"result":{"tabs":[
+  {"tab_id":"w1:t1","label":"1","pane_count":1,"focused":true},
+  {"tab_id":"w1:t2","label":"2","pane_count":1,"focused":false},
+  {"tab_id":"w1:t3","label":"3","pane_count":1,"focused":false},
+  {"tab_id":"w1:t4","label":"4","pane_count":1,"focused":false}
+]}}
+JSON
+fixture panes.json <<'JSON'
+{"result":{"panes":[
+  {"pane_id":"p1","tab_id":"w1:t1","focused":true,"agent":"codex","agent_status":"idle",
+   "agent_session":{"source":"herdr:codex","agent":"codex","kind":"id","value":"019f"}},
+  {"pane_id":"p2","tab_id":"w1:t2","focused":false,"agent_status":"unknown"},
+  {"pane_id":"p3","tab_id":"w1:t3","focused":false,"agent":"claude","agent_status":"idle",
+   "agent_session":{"source":"herdr:claude","agent":"claude","kind":"id","value":"ce04"}},
+  {"pane_id":"p4","tab_id":"w1:t4","focused":false,"agent_status":"unknown",
+   "agent_session":{"source":"herdr:claude","agent":"claude","kind":"id","value":"dead"}}
+]}}
+JSON
+# p1: codex through npx -- argv0 absent, argv[0] is the runtime, name is a thread.
+fixture procinfo_p1.json <<'JSON'
+{"result":{"process_info":{"foreground_process_group_id":100,
+  "foreground_processes":[{"pid":100,"argv":["node","/home/u/.npm/_npx/x/node_modules/.bin/codex"],
+  "name":"MainThread","cmdline":"node /home/u/.npm/_npx/x/node_modules/.bin/codex"}]}}}
+JSON
+# p2: an ordinary node program, no agent in the pane.
+fixture procinfo_p2.json <<'JSON'
+{"result":{"process_info":{"foreground_process_group_id":200,
+  "foreground_processes":[{"pid":200,"argv0":"node","cmdline":"node server.js"}]}}}
+JSON
+# p3: an agent that reports its own name.
+fixture procinfo_p3.json <<'JSON'
+{"result":{"process_info":{"foreground_process_group_id":300,
+  "foreground_processes":[{"pid":300,"argv0":"claude","cmdline":"claude"}]}}}
+JSON
+# p4: node again, but the pane holds only a session ref -- no detected agent.
+fixture procinfo_p4.json <<'JSON'
+{"result":{"process_info":{"foreground_process_group_id":400,
+  "foreground_processes":[{"pid":400,"argv0":"node","cmdline":"node worker.js"}]}}}
+JSON
+run_event tab.focused
+out=$(log)
+check_contains "runtime + detected agent -> the agent" "$out" "tab rename w1:t1 [1] codex"
+check_absent   "the runtime never names that tab"      "$out" "[1] node"
+check_contains "an ordinary node program is untouched" "$out" "tab rename w1:t2 [2] node"
+check_contains "a self-reporting agent is unchanged"   "$out" "tab rename w1:t3 [3] claude"
+check_contains "a session ref alone never names"       "$out" "tab rename w1:t4 [4] node"
+check_absent   "no rename from the stale session ref"  "$out" "[4] claude"
+teardown
+
 t_summary


### PR DESCRIPTION
## Problem

A tab is named after its pane's foreground process. For agents installed from npm, that process is not the agent. The `codex` command on `PATH` is a small JS file with a node shebang, so the kernel starts node and node runs the script. herdr reports the process like this (captured on herdr 0.8.0, Linux):

```
argv0:   null
argv[0]: node
name:    MainThread
cmdline: node /home/u/.npm/_npx/.../node_modules/.bin/codex
```

`ar_pane_program` picks `argv0`, then `argv[0]`, then `name`, so the tab reads `node`. Before v0.2.3 there was no `argv[0]` step and the tab fell through to `name`, which for a node process is its thread name: the tab read `MainThread`. The #6 fix improved that to `node`. This PR gets it to `codex`.

The problem is not Linux-only. macOS builds do send `argv0`, but for a shebang-execed script it also reads `node`. The fix keys on the resolved program name, so it works the same on both platforms.

This matters for agents in particular because the plugin already treats them specially: `NAME_ONLY_PROGRAMS` lists every agent herdr detects, and `icons.sh` gives each one the robot glyph. Neither works for an agent whose process is named `node`.

Which agents are affected depends on the package entrypoint, not the package manager. On one machine with agents installed from npm, five of six launchers on `PATH` resolve to node (codex, opencode, gemini, pi, copilot) against one native binary (claude). Of those five, only the ones whose entrypoint is JavaScript actually show as `node`: opencode's shim execs a native binary, so it reports `opencode` and is fine. Agents installed with pip or pipx have the same problem through `python`, since a console script is a shebang file too.

## Before and after

Two panes in one workspace, both running codex through npx, with `NAME_TABS=1` and `AUTO_INDEX=1`:

```
before  │ [1] node   │ [2] node   │
after   │ [1] codex  │ [2] codex  │
```

## The fix

herdr already knows which agent is in each pane. Its detector looks through runtime wrappers (node, bun, python, shell and PowerShell, see `src/detect/mod.rs`) and writes the result to the pane object as `PaneInfo.agent`. Checked against a live herdr 0.8.0: the panes carrying `.agent` are exactly the set `agent list` reports.

The new rule: if the foreground program is a language runtime or package runner, and the pane has a detected agent, the agent names the tab. The agent is read from the pane list the reconcile already holds (`AR_PANES_JSON`, filled from `api snapshot` or the `pane list` fallback). The plugin does not try to identify agents from `argv` itself. If herdr cannot identify the pane, that is an upstream detection gap (herdr#803, herdr#2779) and the tab just keeps showing the runtime.

The pane's `agent_session` field is not consulted. It is a resume reference, and herdr#803 shows a pane can carry one while detection reports nothing (`agent: None`, absent from `agent list`). Naming from it could rename a tab off a stale reference.

Both conditions are required:

- A plain `node server.js` tab has no agent in its pane and keeps its name.
- An agent that reports its own name is not a runtime and never reaches the lookup.

The runtimes are a list, `WRAPPER_PROGRAMS` (`node bun deno npx bunx npm pnpm yarn python python3 uv uvx pipx ruby`), rather than "anything in a pane with an agent". A fixed list means the substitution cannot fire on an unrelated program that happens to share a pane with an agent, and it follows the same `declare -p` override convention as `SHELLS` and `IGNORED_PROGRAMS`.

## What does not change

- `SHOW_PROGRAM_ARGS=1` still shows the command line for non-agent programs. A substituted tab passes the agent name as both program and cmdline, so it reads `codex` rather than the npx invocation, same as a directly launched agent in `NAME_ONLY_PROGRAMS`.
- `NAME_ONLY_PROGRAMS`, `ICONS_ENABLED` and `PROGRAM_ALIASES` now see the agent name, so a wrapped agent gets its glyph and can be aliased like any other program.
- `HIDE_SHELL`, `SHELLS` and `IGNORED_PROGRAMS` are untouched; none of those paths runs an agent. A suspended agent's bare prompt still names the tab by the shell, since the foreground leader is the shell and the shell is not a wrapper.
- Manual renames are unaffected; the state machine never sees this.

Two known edge cases, both limited to panes with a detected agent:

- While the agent session is alive, a different wrapper program in the foreground of that pane (say `npm test` next to a backgrounded codex) also names the tab after the agent. This is the cost of trusting herdr's per-pane answer. In practice the tab reads as "the codex pane", which is usually what you want anyway.
- The preexec/precmd fast path names by the typed word and does not consult the pane, so launching a wrapped agent can briefly show `npx` or `node` until the next full reconcile (herdr's detection event triggers one) settles it.

## Cost

No extra herdr call on any version. The lookup reads pane objects the reconcile already fetched, at one local jq invocation per wrapper pane.

## Tests

`tests/test_reconcile.sh` scenario 19 drives the real engine against a fake herdr and covers four cases in one reconcile:

- codex through npx (no `argv0`, `argv[0]` of `node`, `name` of `MainThread`) with the agent on the pane object: named `codex`, and a `check_absent` verifies `node` never names that tab
- a plain `node server.js` pane with no agent: still `node`
- a self-reporting `claude` pane: unchanged
- a node pane whose pane object carries only an `agent_session` ref (the herdr#803 state): still `node`

The scenario ships no `agents.json` fixture, so the name can only come from the pane fields. If the code ever grew an `agent list` dependency, it would see an empty list and the `codex` assertion would fail.

`./tests/run.sh` passes locally on Linux, 297 tests. CI covers macOS. `make lint` reports nothing beyond the findings already on `main`.
