### PR TITLE
fix(naming): decide by codepoint what already gets cut by codepoint

### DIFF
--- a/naming.sh
+++ b/naming.sh
@@ -249,13 +249,29 @@ ar_trunc() {
 # under a C locale a multibyte string counts several bytes per character, and
 # that is the half two callers below used to take as a decision.
 #
-# Only a string that fails the cheap test pays for jq, which is a label at or near
-# its budget carrying a character outside ASCII. Every plain one is free. A jq
-# that cannot run answers "does not fit", which is what both callers did before
-# this existed.
+# Only a string that fails the cheap test AND carries a byte outside ASCII pays
+# for jq, which is a label at its budget in a language that needs one. A jq that
+# cannot run answers "does not fit", which is what both callers did before this
+# existed.
+#
+# The one-way property holds where bash counts bytes, which is C and POSIX, and
+# where it counts characters of valid UTF-8. A legacy multibyte locale that is not
+# UTF-8 is outside it: bytes there may count as one shell character and more than
+# one jq codepoint, so the cheap accept could pass something jq would refuse. The
+# plugin is not tested in one. Bytes that are not valid UTF-8 have no codepoint
+# length at all; jq decodes them to replacements, so a name made of them may now
+# reach a tab as its own bytes where it once reached it as U+FFFD.
 ar_fits() {
   local n
   [ "${#1}" -le "$2" ] && return 0
+  # Where every byte is ASCII the two counts are the same number, so the test
+  # above was exact in both directions and the answer is already known. That is
+  # nearly every label and every branch, and it keeps them at no process at all:
+  # only a value carrying a byte above 0x7F, and only one at its budget, asks jq.
+  case $1 in
+  *[!$'\01'-$'\177']*) : ;;
+  *) return 1 ;;
+  esac
   n=$(printf '%s' "$1" | jq -Rrs 'length' 2>/dev/null) || return 1
   [ -n "$n" ] && [ "$n" -le "$2" ]
 }
@@ -421,8 +437,18 @@ ar_shorten() {
     return 0
   fi
   branch=${branch##*/}
-  cut=${branch:0:$max}
-  next=${branch:$max:1}
+  # Deciding to shorten is one thing and cutting is another: bash indexes by BYTE
+  # under a C locale, so a name carrying anything outside ASCII was sliced at the
+  # wrong offset and cut back to an earlier separator than it needed. Plain ASCII,
+  # which is nearly every branch, is indexed exactly right by bash and pays no
+  # process; only a name with a byte above 0x7F asks jq. $next is then read at the
+  # width of the head, which is bytes under C and characters elsewhere, and is the
+  # right offset in either.
+  case $branch in
+  *[!$'\01'-$'\177']*) cut=$(ar_trunc "$branch" "$max") ;;
+  *) cut=${branch:0:$max} ;;
+  esac
+  next=${branch:${#cut}:1}
   # When the character that did not fit is itself a separator the head already
   # ends on a whole word, and cutting again would throw one away.
   case $next in
@@ -831,10 +857,16 @@ ar_format() {
     if [ -n "$title" ]; then
       # ${name% *} is the whole string when there is no space in it, so a single
       # long word is left cut where it was. The half-budget floor is what stops
-      # "Investigate" from becoming "I". Counting bytes is deliberate here: the
-      # floor is a heuristic, not the cut.
+      # "Investigate" from becoming "I".
+      #
+      # Counted the same way the budget is. Calling it a heuristic and leaving it
+      # in bytes was wrong: the floor still compares against half of a CHARACTER
+      # budget, and under a C locale a four-byte glyph cleared it on its own, so a
+      # genuinely over-budget title came back as the glyph and nothing else, which
+      # is the symptom this commit exists to remove. ar_fits is asked the opposite
+      # question, so a floor of n is "does not fit in n-1".
       local short=${name% *}
-      [ "${#short}" -ge $(( max / 2 )) ] && name=$short
+      ar_fits "$short" $(( max / 2 - 1 )) || name=$short
     fi
   fi
   AR_ACTIVITY=$name

--- a/naming.sh
+++ b/naming.sh
@@ -241,6 +241,25 @@ ar_trunc() {
   printf '%s' "$cut"
 }
 
+# ar_fits <string> <max> -> 0 when the string is at most <max> codepoints wide.
+#
+# The same byte test ar_trunc opens with, and it holds in only one direction: a
+# string of no more bytes than max is of no more codepoints either, so passing is
+# proof it fits and costs nothing. FAILING is not proof of the opposite, because
+# under a C locale a multibyte string counts several bytes per character, and
+# that is the half two callers below used to take as a decision.
+#
+# Only a string that fails the cheap test pays for jq, which is a label at or near
+# its budget carrying a character outside ASCII. Every plain one is free. A jq
+# that cannot run answers "does not fit", which is what both callers did before
+# this existed.
+ar_fits() {
+  local n
+  [ "${#1}" -le "$2" ] && return 0
+  n=$(printf '%s' "$1" | jq -Rrs 'length' 2>/dev/null) || return 1
+  [ -n "$n" ] && [ "$n" -le "$2" ]
+}
+
 # ar_context_dir <pane directory> <workspace base label> -> the directory part of
 # the context, or "" when the directory says nothing worth a tab's width.
 #
@@ -396,7 +415,7 @@ ar_branch_label() {
 # than one being cut through the middle.
 ar_shorten() {
   local branch=$1 max=$2 cut next
-  [ "${#branch}" -le "$max" ] && { printf '%s' "$branch"; return 0; }
+  ar_fits "$branch" "$max" && { printf '%s' "$branch"; return 0; }
   if [[ $branch =~ $_AR_BRANCH_KEY ]]; then
     ar_upper "${BASH_REMATCH[2]}"
     return 0
@@ -798,8 +817,13 @@ ar_format() {
   name=${name# }
   name=${name% }
 
-  # Cut to the budget (ar_trunc counts codepoints, not bytes).
-  if [ "${#name}" -gt "$max" ]; then
+  # Cut to the budget, in codepoints. Asking bash for the width instead put a
+  # label that fits into this branch under a C locale: ar_trunc handed it straight
+  # back, having correctly found nothing to cut, and the word-boundary trim below
+  # then took a word off a label that was never over budget. With a wide enough
+  # glyph in front, the only space is the one behind it and the trim left the
+  # glyph alone on the tab.
+  if ! ar_fits "$name" "$max"; then
     name=$(ar_trunc "$name" "$max")
     # A title is a sentence, so cut it at a word boundary rather than mid-word --
     # but only when that leaves most of the budget, since "Investigate" tells you

--- a/tests/test_naming.sh
+++ b/tests/test_naming.sh
@@ -243,6 +243,9 @@ check "ICON_MAP override end to end" "$g_agent nosuchprog" \
 # A glyph is one codepoint, so "<glyph> <name>" must be truncated by codepoint,
 # never mid-byte. node is not name-only, so its cmdline is long enough to cut:
 # MAX_NAME_LEN=6 keeps the glyph, the space, and 4 chars of the name.
+# Four bytes, one codepoint: the widest ordinary case, and what makes the floor
+# fail when it counts bytes.
+g_sushi=$(printf '\360\237\215\243')
 check "icon+name truncates on codepoint boundary" "$g_node node" \
   "$(ICONS_ENABLED=1 MAX_NAME_LEN=6 SHOW_PROGRAM_ARGS=1 ar_format 'node' 'nodeandmore')"
 
@@ -252,6 +255,12 @@ check "icon+name truncates on codepoint boundary" "$g_node node" \
 # glyph, leaving the glyph alone on the tab.
 check "a fitting icon+title is untouched" "$g_node nöde" \
   "$(LC_ALL=C ICONS_ENABLED=1 MAX_TITLE_LEN=7 ar_format 'node' '' "$(printf 'n\303\266de')")"
+# A title that IS over budget still has to keep a word. The half-budget floor
+# decides that, and counting it in bytes let a four-byte glyph clear it alone, so
+# an over-budget title came back as the glyph and nothing else.
+# An array cannot be a command prefix, so this one sets up in a subshell.
+check "an over-budget icon+title keeps a word" "$g_sushi abcdef" \
+  "$(LC_ALL=C; ICONS_ENABLED=1; ICON_MAP=("node=$g_sushi"); MAX_TITLE_LEN=8; ar_format 'node' '' 'abcdef ghijkl')"
 
 # ---- HIDE_SHELL: every shell-ish case names the tab nothing (issue #5) ----
 # The empty label is what makes herdr fall back to rendering its own tab number,
@@ -644,6 +653,11 @@ check "a branch that fits is left whole" "feat/oauth" "$(ar_branch_label 'feat/o
 # to the first separator. Eleven codepoints, twenty bytes, budget of twelve.
 check "a fitting multibyte branch is left whole" "абв-где-жзи" \
   "$(LC_ALL=C MAX_BRANCH_LEN=12 ar_branch_label "$(printf '\320\260\320\261\320\262-\320\263\320\264\320\265-\320\266\320\267\320\270')" 'main')"
+# And one that genuinely overflows must be cut at the same place in either
+# locale: deciding to shorten was fixed before the offset the cut uses was.
+# Fifteen codepoints in a budget of twelve, so it reduces either way.
+check "an overlong multibyte branch cuts alike" "абв-где" \
+  "$(LC_ALL=C MAX_BRANCH_LEN=12 ar_branch_label "$(printf '\320\260\320\261\320\262-\320\263\320\264\320\265-\320\266\320\267\320\270\320\272\320\273\320\274\320\275')" 'main')"
 # The trunk says nothing -- every tab in the repository would carry it alike --
 # and which branch that is comes from the repository rather than from a list of
 # names, so a team whose trunk is "develop" gets the same silence.

--- a/tests/test_naming.sh
+++ b/tests/test_naming.sh
@@ -92,6 +92,27 @@ check "truncates to MAX_NAME_LEN" "12345678901234567890" \
 check "multibyte truncation is clean" "ünïcödé" \
   "$(MAX_NAME_LEN=7 ar_format 'x' 'ünïcödéxxxxxxx')"
 
+# And a label that FITS must be left alone, which is a different claim: bash
+# counts bytes under a C locale (herdr may launch a plugin with no LC_*), so a
+# multibyte label inside its budget still looked over it. What followed was not a
+# cut, since ar_trunc correctly found nothing to cut, but the word-boundary trim
+# that runs after one, which took a whole word off a label that fitted. Run under
+# LC_ALL=C, because that is the only place the bug exists.
+# A TITLE, because the word-boundary trim that does the damage runs only for one.
+# Nine codepoints and thirteen bytes, in a budget of nine: it fits, ar_trunc finds
+# nothing to cut, and the trim used to take "x" off anyway.
+check "a fitting multibyte title is untouched" "ünïcödé x" \
+  "$(LC_ALL=C MAX_TITLE_LEN=9 ar_format 'claude' '' "$(printf '\303\274n\303\257c\303\266d\303\251 x')")"
+# ---- ar_fits: the byte test holds in one direction only ----
+check_rc "ascii inside the budget fits" 0 "$(ar_fits 'abcdef' 8; echo $?)"
+check_rc "ascii over the budget does not" 1 "$(ar_fits 'abcdefghij' 8; echo $?)"
+# Eight codepoints, sixteen bytes: the cheap test fails and only a codepoint
+# count can say it fits.
+check_rc "multibyte inside the budget fits under C" 0 \
+  "$(LC_ALL=C ar_fits "$(printf 'àààààààà')" 8; echo $?)"
+check_rc "multibyte over the budget does not" 1 \
+  "$(LC_ALL=C ar_fits "$(printf 'ààààààààà')" 8; echo $?)"
+
 # ---- icons ----
 # Expected glyphs are built from explicit UTF-8 byte escapes rather than pasted
 # literals: bash 3.2 has no $'\uXXXX', and the Private Use Area codepoints these
@@ -224,6 +245,13 @@ check "ICON_MAP override end to end" "$g_agent nosuchprog" \
 # MAX_NAME_LEN=6 keeps the glyph, the space, and 4 chars of the name.
 check "icon+name truncates on codepoint boundary" "$g_node node" \
   "$(ICONS_ENABLED=1 MAX_NAME_LEN=6 SHOW_PROGRAM_ARGS=1 ar_format 'node' 'nodeandmore')"
+
+# The other half of that claim: a glyph plus a label that FITS must be left
+# whole. Under a C locale the byte count made this look over budget, and the
+# word-boundary trim then cut back to the only space there is, the one behind the
+# glyph, leaving the glyph alone on the tab.
+check "a fitting icon+title is untouched" "$g_node nöde" \
+  "$(LC_ALL=C ICONS_ENABLED=1 MAX_TITLE_LEN=7 ar_format 'node' '' "$(printf 'n\303\266de')")"
 
 # ---- HIDE_SHELL: every shell-ish case names the tab nothing (issue #5) ----
 # The empty label is what makes herdr fall back to rendering its own tab number,
@@ -611,6 +639,11 @@ HOME=$HOME_SAVE
 # A branch qualifies the context: "api › feat/oauth › nvim" says which slice of
 # the project the tab is on, where the directory alone says only which project.
 check "a branch that fits is left whole" "feat/oauth" "$(ar_branch_label 'feat/oauth' 'main')"
+# The same claim under a C locale, where bash measures the name in bytes: a
+# non-ASCII branch inside its budget looked over it, and the reduction cut it back
+# to the first separator. Eleven codepoints, twenty bytes, budget of twelve.
+check "a fitting multibyte branch is left whole" "абв-где-жзи" \
+  "$(LC_ALL=C MAX_BRANCH_LEN=12 ar_branch_label "$(printf '\320\260\320\261\320\262-\320\263\320\264\320\265-\320\266\320\267\320\270')" 'main')"
 # The trunk says nothing -- every tab in the repository would carry it alike --
 # and which branch that is comes from the repository rather than from a list of
 # names, so a team whose trunk is "develop" gets the same silence.


### PR DESCRIPTION
A label or a branch name that fits its budget can be shortened anyway under a C locale, which is one herdr may launch a plugin in.

## Reproducing it

On `v0.8.0`, no configuration beyond an icon:

```sh
ICONS_ENABLED=1
ICON_MAP=("claude=😀😀😀😀")
MAX_TITLE_LEN=28
# title: "alpha beta gamma delta"   -> 22 codepoints, label 27 of 28

LC_ALL=C            ->  😀😀😀😀 alpha beta gamma
LC_ALL=en_US.UTF-8  ->  😀😀😀😀 alpha beta gamma delta
```

And with a glyph in front of a dash-joined label, where the only space is the one behind the glyph, the tab can lose its label completely.

`ar_shorten` has it too:

```sh
ar_shorten 'абв-где-жзи' 12      # 11 codepoints, 20 bytes

LC_ALL=C            ->  абв
LC_ALL=en_US.UTF-8  ->  абв-где-жзи
```

## Why

Both sites open with a byte-length test, and `ar_trunc` already explains why that is sound:

> The length test is a byte count on purpose -- a string of fewer bytes than max is also of fewer codepoints, so the fork is skipped for every label that does not need it.

That holds in one direction only. Passing it proves the value fits; **failing it proves nothing**, because bash counts bytes under a C locale. Both callers treated the failure as a decision.

In `ar_format` the damage is not the cut. `ar_trunc` is asked for one and correctly returns the string untouched, having found nothing to remove. What follows is the word-boundary trim that runs *after* a cut, and it takes a whole word off a label that was inside its budget.

In `ar_shorten` the reduction runs instead, and a branch inside its budget comes back cut to its first separator.

## The fix

`ar_fits` draws the distinction once, and both callers ask it instead. Two further places were counting bytes to decide *how* to shorten rather than *whether*, and are fixed with it: `ar_shorten` indexed the cut itself by byte, and the half-budget floor in `ar_format` compared bytes against half of a character budget, so a four-byte glyph cleared it alone.

The cheap test stays exactly where it was. Where every byte is ASCII the two counts are the same number, so it answers on its own in both directions and nothing forks; only a value at its budget carrying a byte above `0x7F` asks jq. Measured on an overlong ASCII branch: `ar_shorten` 64 µs before, 73 µs after; `ar_format` 2557 µs before, 2578 µs after.

A jq that cannot run answers "does not fit", which is what both callers did before.

## Scope

The one-way property holds where bash counts bytes and where it counts characters of valid UTF-8. A legacy multibyte locale that is not UTF-8 is outside it, and bytes that are not valid UTF-8 have no codepoint length at all; both are noted in the comments rather than left to imply more.

## Tests

Five, each verified to fail on the commit before it and to fail for the right reason:

- a title of 9 codepoints and 13 bytes in a budget of 9
- an icon and title of 6 codepoints and 9 bytes in a budget of 7
- a branch of 11 codepoints and 20 bytes in a budget of 12
- an over-budget branch of 15 codepoints, which must cut at the same place in either locale
- an over-budget title behind a four-byte glyph, which must keep a word

`./tests/run.sh` passes (277), `make lint-sh` and `BASH_COMPAT=3.2` are clean.
