### PR TITLE
feat(naming): condense an agent title into keywords

### DIFF
--- a/automatic-rename.sh
+++ b/automatic-rename.sh
@@ -840,12 +840,24 @@ ar_tab_name() {
       #
       # The glyph and the space behind it are prepended BEFORE that truncation
       # and come out of the same budget, so they are reserved here; without that
-      # the tail of a full-length label is what gets cut. ICON_STYLE=name shows
-      # no glyph, so it reserves nothing.
+      # the tail of a full-length label is what gets cut.
+      #
+      # The real glyph, not an allowance for one. ar_condense_title measures what
+      # it is handed, in codepoints, so the reserve has to BE the text that will
+      # share the label: a two-character guess is right only for the one-glyph
+      # case, and wrong in both directions elsewhere. An ICON_MAP entry may be
+      # any string, and its extra characters would cut a word in half at the end
+      # -- the one thing condensing exists to prevent. A program with no glyph
+      # reserves nothing, rather than shortening the label to make room for
+      # something that never arrives. ar_icon is a lookup, no subshell.
       if [ "${TITLE_CONDENSE:-0}" = "1" ]; then
-        local reserve=""
-        if [ "${ICONS_ENABLED:-0}" = "1" ] && [ "${ICON_STYLE:-name_and_icon}" != "name" ]; then
-          reserve="  "
+        local reserve="" style=${ICON_STYLE:-name_and_icon}
+        if [ "${ICONS_ENABLED:-0}" = "1" ] && [ "$style" != "name" ]; then
+          reserve=$(ar_icon "$AR_PANE_AGENT")
+          # ar_format drops a lone fallback glyph under ICON_STYLE=icon, so no
+          # room is kept for one it will not draw.
+          [ "$style" = "icon" ] && [ "$reserve" = "${ICON_FALLBACK:-}" ] && reserve=""
+          [ -n "$reserve" ] && reserve="$reserve "
         fi
         condensed=$(ar_condense_title "$title" "$reserve")
         [ -n "$condensed" ] && title=$condensed

--- a/automatic-rename.sh
+++ b/automatic-rename.sh
@@ -799,7 +799,7 @@ ar_branch_of() {
 # failure); a successful HIDE_SHELL computation returns 0 with EMPTY output, so
 # the caller must read the status, not the string, to tell the two apart.
 ar_tab_name() {
-  local pane info prog="" cmd="" title=""
+  local pane info prog="" cmd="" title="" condensed=""
   pane=$(ar_resolve_pane "$1" "$2" "$3" "${4:-}")
   [ -n "$pane" ] || return 1
   # The caller may already hold this pane's facts, lifted onto the tab row -- but
@@ -831,6 +831,25 @@ ar_tab_name() {
         "$AR_PANE_DIR_LC" "$AR_PANE_AGENT")
     fi
     if [ -n "$title" ]; then
+      # What survived is prose, and ar_format truncates it to fit the budget, so
+      # the words that say WHICH task this is are the ones it drops. Condensing
+      # first spends that budget on nouns instead. It selects, never generates:
+      # a title it cannot shorten comes back empty and the sentence is kept.
+      # Both title sources land here, so a topic read out of a transcript is
+      # condensed the same way the terminal title is.
+      #
+      # The glyph and the space behind it are prepended BEFORE that truncation
+      # and come out of the same budget, so they are reserved here; without that
+      # the tail of a full-length label is what gets cut. ICON_STYLE=name shows
+      # no glyph, so it reserves nothing.
+      if [ "${TITLE_CONDENSE:-0}" = "1" ]; then
+        local reserve=""
+        if [ "${ICONS_ENABLED:-0}" = "1" ] && [ "${ICON_STYLE:-name_and_icon}" != "name" ]; then
+          reserve="  "
+        fi
+        condensed=$(ar_condense_title "$title" "$reserve")
+        [ -n "$condensed" ] && title=$condensed
+      fi
       ar_branch_of "$AR_PANE_DIR" >/dev/null
       ar_label "$AR_PANE_DIR" "${5:-}" "$AR_BRANCH" "$AR_PANE_AGENT" "" "$title"
       return 0

--- a/config.example.sh
+++ b/config.example.sh
@@ -160,8 +160,12 @@
 # label changed on every status change. The brand is removed only at the very
 # front and only when a non-alphanumeric follows it, so a title that merely starts
 # with the same letter keeps it, and the case of ASCII letters is ignored.
+# opencode brands with letters rather than a glyph ("OC | Reviewing unpushed
+# commits"), and the entry handles it the same way: the brand comes off and the
+# strip takes the separator behind it. Keying it to the agent is what keeps it
+# off everyone else, where "API | authentication migration" is content.
 # Assigning the array replaces the default.
-# TITLE_BRANDS=("pi=π" "omp=π")
+# TITLE_BRANDS=("pi=π" "omp=π" "opencode=OC")
 
 # 1 = condense a title into its keywords instead of showing the agent's sentence
 # with the tail cut off. MAX_TITLE_LEN takes the END off a title, which is where
@@ -180,11 +184,19 @@
 
 # Verbs dropped when a title OPENS with one. Every agent tab reading "Fix ..." or
 # "Add ..." spends its first word on something the tab beside it also says. Only
-# at the front, so "the auth rewrite needs review" keeps its "review". The list
-# matches spelling rather than part of speech, so a title whose subject is one of
-# these words ("Port forwarding is broken" -> "forwarding-broken") wants the word
-# taken out of the list. Assigning the array replaces the default.
-# TITLE_LEAD_VERBS=(review adjust add fix update create make check investigate debug refactor implement write set setup configure explore improve build test run clean remove delete migrate port rename draft plan research diagnose audit)
+# at the front, so "the auth rewrite needs review" keeps its "review".
+#
+# Measured against 65 titles Claude Code wrote across 1800 real sessions: the
+# list fires on 26 of them and 21 of those gain a content word in the same
+# budget, with no two of the 65 colliding whether the rule is on or off.
+#
+# It matches spelling rather than part of speech, so a title whose subject shares
+# a listed spelling loses it ("Plan needs approval" -> "needs-approval"), and
+# taking that word out is the answer. The failure worth knowing about is a
+# collision: "Review flashcard generation" and "Implement flashcard generation"
+# both reduce to "flashcard-generation". Assigning the array replaces the
+# default; TITLE_LEAD_VERBS=() drops nothing.
+# TITLE_LEAD_VERBS=(review adjust add fix update create make check investigate debug refactor implement write set setup configure explore improve build test run clean remove delete migrate rename draft plan research diagnose audit analyze troubleshoot optimize show)
 
 # Words dropped wherever they appear: a label is not a sentence, so articles,
 # prepositions and phrasal-verb particles only spend the budget. Assigning the

--- a/config.example.sh
+++ b/config.example.sh
@@ -161,11 +161,11 @@
 # front and only when a non-alphanumeric follows it, so a title that merely starts
 # with the same letter keeps it, and the case of ASCII letters is ignored.
 # opencode brands with letters rather than a glyph ("OC | Reviewing unpushed
-# commits"), and the entry handles it the same way: the brand comes off and the
-# strip takes the separator behind it. Keying it to the agent is what keeps it
-# off everyone else, where "API | authentication migration" is content.
+# commits"); adding "opencode=OC" strips that. It is not in the default, because
+# a brand is removed wherever a non-alphanumeric or the end of the string follows
+# it: the entry would also turn "OC-192 incident" into "192 incident".
 # Assigning the array replaces the default.
-# TITLE_BRANDS=("pi=π" "omp=π" "opencode=OC")
+# TITLE_BRANDS=("pi=π" "omp=π")
 
 # 1 = condense a title into its keywords instead of showing the agent's sentence
 # with the tail cut off. MAX_TITLE_LEN takes the END off a title, which is where
@@ -186,9 +186,11 @@
 # "Add ..." spends its first word on something the tab beside it also says. Only
 # at the front, so "the auth rewrite needs review" keeps its "review".
 #
-# Measured against 65 titles Claude Code wrote across 1800 real sessions: the
-# list fires on 26 of them and 21 of those gain a content word in the same
-# budget, with no two of the 65 colliding whether the rule is on or off.
+# Measured against every title Claude Code generated on one machine over three
+# weeks, 65 of them: this list fires on 36 and 31 of those gain a content word in
+# the same budget, with no two of the 65 colliding whether the rule is on or off.
+# Where a session was never titled the engine condenses the first typed prompt
+# instead, and that population is not covered by those numbers.
 #
 # It matches spelling rather than part of speech, so a title whose subject shares
 # a listed spelling loses it ("Plan needs approval" -> "needs-approval"), and

--- a/config.example.sh
+++ b/config.example.sh
@@ -174,9 +174,11 @@
 # leading verb and the filler and joins what is left, so the same budget carries
 # "nightly-ETL-job-drops-rows" instead.
 #
-# It selects and never generates: the words are the agent's own, in the order it
+# It selects rather than generates: the words are the agent's own, in the order it
 # wrote them, on the reasoning that it put the salient ones first. A title it
-# cannot shorten to anything (all filler) is left as the sentence.
+# cannot shorten to anything (all filler) is left as the sentence. The one
+# exception is a first word longer than the whole budget, which is cut rather than
+# dropped, since dropping it would leave no label at all.
 #
 # Off by default, so a config that does not name it gets exactly what
 # AGENT_TITLES has always rendered.
@@ -186,11 +188,13 @@
 # "Add ..." spends its first word on something the tab beside it also says. Only
 # at the front, so "the auth rewrite needs review" keeps its "review".
 #
-# Measured against every title Claude Code generated on one machine over three
-# weeks, 65 of them: this list fires on 36 and 31 of those gain a content word in
-# the same budget, with no two of the 65 colliding whether the rule is on or off.
-# Where a session was never titled the engine condenses the first typed prompt
-# instead, and that population is not covered by those numbers.
+# Measured against the last title Claude Code generated in each of 65 titled
+# sessions on one machine over three weeks, which is the title the engine reads:
+# this list fires on 35 and 30 of those gain a content word in the same budget,
+# with no two DIFFERENT titles among the 65 colliding whether the rule is on or
+# off (two sessions share a title, and those condense alike). Where a session
+# was never titled the engine condenses the first typed prompt instead, and that
+# population is not covered by those numbers.
 #
 # It matches spelling rather than part of speech, so a title whose subject shares
 # a listed spelling loses it ("Plan needs approval" -> "needs-approval"), and

--- a/config.example.sh
+++ b/config.example.sh
@@ -163,6 +163,46 @@
 # Assigning the array replaces the default.
 # TITLE_BRANDS=("pi=π" "omp=π")
 
+# 1 = condense a title into its keywords instead of showing the agent's sentence
+# with the tail cut off. MAX_TITLE_LEN takes the END off a title, which is where
+# the words that say WHICH task this is tend to sit: "Investigate why the nightly
+# ETL job drops rows" becomes "Investigate why the nightly". Condensing drops a
+# leading verb and the filler and joins what is left, so the same budget carries
+# "nightly-ETL-job-drops-rows" instead.
+#
+# It selects and never generates: the words are the agent's own, in the order it
+# wrote them, on the reasoning that it put the salient ones first. A title it
+# cannot shorten to anything (all filler) is left as the sentence.
+#
+# Off by default, so a config that does not name it gets exactly what
+# AGENT_TITLES has always rendered.
+# TITLE_CONDENSE=0
+
+# Verbs dropped when a title OPENS with one. Every agent tab reading "Fix ..." or
+# "Add ..." spends its first word on something the tab beside it also says. Only
+# at the front, so "the auth rewrite needs review" keeps its "review". The list
+# matches spelling rather than part of speech, so a title whose subject is one of
+# these words ("Port forwarding is broken" -> "forwarding-broken") wants the word
+# taken out of the list. Assigning the array replaces the default.
+# TITLE_LEAD_VERBS=(review adjust add fix update create make check investigate debug refactor implement write set setup configure explore improve build test run clean remove delete migrate port rename draft plan research diagnose audit)
+
+# Words dropped wherever they appear: a label is not a sentence, so articles,
+# prepositions and phrasal-verb particles only spend the budget. Assigning the
+# array replaces the default; TITLE_FILLER_WORDS=() drops nothing.
+# TITLE_FILLER_WORDS=(a an the to for of on in at and or with from into via why how what that if whether is are be it its this up out off down over back)
+
+# What joins the surviving words. The default fuses the label into one token, the
+# shape every other tab name has; " " reads as the phrase instead. Its length is
+# charged to MAX_TITLE_LEN like any other character.
+# TITLE_WORD_SEPARATOR=-
+
+# Casing. "fold" downcases every word except an all-caps-and-digits identifier: a
+# sentence-case capital is the agent writing a sentence rather than signal, while
+# the shape of "ETL" carries meaning. "lower" folds the identifiers too, "keep"
+# leaves the agent's casing alone. Only ASCII letters are folded, so a non-ASCII
+# capital reaches the label as written.
+# TITLE_CASE=fold
+
 # Name shown at a bare prompt. Defaults to your $SHELL's basename.
 # SHELL_NAME=zsh
 

--- a/naming.sh
+++ b/naming.sh
@@ -211,15 +211,23 @@ declare -p TITLE_BRANDS >/dev/null 2>&1 || TITLE_BRANDS=("pi="$'\317\200' "omp="
 # spends its first word saying what the tab beside it also says, so a LEADING one
 # is dropped. Leading only, so "the auth rewrite needs review" keeps its "review".
 #
-# Measured rather than imagined. The corpus is every title Claude Code generated
-# on one machine over three weeks: 65 of them. It is not a sample of the 1800
-# transcripts there, which are mostly headless "sdk-cli" runs and subagents that
-# are never titled; interactive sessions are titled, and an interactive session
-# is the only kind that occupies a tab.
+# Measured rather than imagined. The corpus is the LAST title Claude Code
+# generated in each of the 65 titled sessions on one machine over three weeks,
+# which is the title the engine itself reads (transcript.sh takes last(inputs)).
+# Measuring the first title instead gives 36 and 31, one session having been
+# retitled while it ran; the numbers below are the selection that ships.
 #
-# THIS list fires on 36 of the 65, and 31 of those get a content word back inside
-# the same budget. No two of the 65 condense to the same label with the list on or
-# off, so the drop buys information without costing distinctness. "analyze" was
+# The other 1735 transcripts there are subagent runs and headless "sdk-cli"
+# invocations, neither of which Claude Code titles at all. Those are unlikely to
+# be sitting in a tab somebody is reading, though nothing stops one being launched
+# in a terminal, so read this as "titled sessions" rather than "every tab".
+#
+# THIS list fires on 35 of the 65, and 30 of those get a content word back inside
+# the same budget. No two DIFFERENT titles among the 65 condense to the same
+# label with the list on or off, so the drop buys information without costing
+# distinctness. (Two of the 65 are the same title from two sessions, and those
+# do condense alike, which is the corpus repeating itself rather than the rule
+# losing anything.) "analyze" was
 # the most frequent opener the first hand-written list had missed, seven of the
 # 65; "troubleshoot", "optimize" and "show" one each.
 #
@@ -689,6 +697,11 @@ ar_condense_title() {
       ([$max - ($reserved | length), 0] | max) as $m
     | ($verbs  | ascii_downcase | split(" ")) as $verb
     | ($filler | ascii_downcase | split(" ")) as $fill
+    # The filler list as WRITTEN, alongside the folded one, and the identifier
+    # shape defined once for the two rules that share it. Duplicating the pattern
+    # was called a guarantee that they could not drift, which it was not.
+    | ($filler | split(" ")) as $fillraw
+    | "^[A-Z0-9]{2,}$" as $ident
     # Separators inside the title are word breaks, not characters, so
     # "tab/workspace" is two words rather than one long one.
     #
@@ -704,20 +717,31 @@ ar_condense_title() {
     | (if ($words | length) > 0 and ($verb | index($words[0] | ascii_downcase))
        then $words[1:] else $words end)
     # An all-caps token is an identifier, and the casing rule below spares it for
-    # exactly that reason. Filler is matched case-insensitively, so without this
-    # the two rules disagree and the identifier loses: "Investigate IT outage"
-    # became "outage" and "Fix OR parser precedence" became "parser-precedence",
-    # because "it" and "or" are filler. The same {2,} test as the casing rule, so
-    # the two cannot drift; a one-letter identifier is not covered, and the only
-    # single letter in the default filler list is "a".
-    | map(. as $w | select(($w | test("^[A-Z0-9]{2,}$")) or ($fill | index($w | ascii_downcase) | not)))
+    # exactly that reason. Filler is matched without regard to case, so without
+    # this the two rules disagree and the identifier loses: "Investigate IT
+    # outage" became "outage" and "Fix OR parser precedence" became
+    # "parser-precedence", because "it" and "or" are filler.
+    #
+    # Listing the word in capitals overrides that and drops it again, which is
+    # the escape hatch for a project whose filler really is an all-caps token.
+    # Lower case in the list does not, so a title carrying "RFC" keeps it whether
+    # or not somebody wrote "rfc" there. Emphatic prose keeps its capitals too:
+    # "Fix THE parser" reads as "THE-parser", the rule having no way to tell a
+    # shouted article from a short identifier.
+    #
+    # Two characters at least, matching the casing rule. A single letter is not
+    # covered, so "Fix A record resolution" loses its "A".
+    | map(. as $w | select(
+        (($fill | index($w | ascii_downcase)) | not)
+        or (($w | test($ident)) and (($fillraw | index($w)) | not))
+      ))
     # Casing: a sentence-case capital is the agent writing a sentence, not
     # signal; an all-caps-and-digits token is an identifier whose shape means
     # something. "fold" spares only the identifiers, "lower" folds those too,
     # "keep" touches nothing. Anything else behaves as the "fold" default.
     | map(if $case == "keep" then .
           elif $case == "lower" then ascii_downcase
-          elif test("^[A-Z0-9]{2,}$") then .
+          elif test($ident) then .
           else ascii_downcase end)
     | reduce .[] as $w ({out: "", done: false};
         if .done then .

--- a/naming.sh
+++ b/naming.sh
@@ -185,6 +185,42 @@ declare -p TITLE_IGNORE >/dev/null 2>&1 || TITLE_IGNORE=("claude code" "codex cl
 # kinds (src/detect/mod.rs, herdr 0.8.2) and both are the same program's brand.
 declare -p TITLE_BRANDS >/dev/null 2>&1 || TITLE_BRANDS=("pi="$'\317\200' "omp="$'\317\200')
 
+# 1 = condense a title into its keywords before it becomes a label, instead of
+# showing the agent's sentence with the tail cut off. A title arrives as prose
+# ("Adjust the screensaver timeout") and MAX_TITLE_LEN takes the end off it, so
+# the words that say WHICH task this is are the first to go. Condensing drops a
+# leading verb and the filler and joins what is left, which fits the same budget
+# while keeping the nouns: "screensaver-timeout".
+#
+# Off by default, so a config that does not name it gets the title exactly as
+# AGENT_TITLES has always rendered it. That is also what keeps this a bolt-on:
+# every released test asserts the sentence, and a default of 1 would rewrite
+# their expectations rather than add to them.
+: "${TITLE_CONDENSE:=0}"
+
+# Verbs an agent opens a title with. Every tab reading "Fix ..." or "Add ..."
+# spends its first word saying what the tab beside it also says, so a LEADING one
+# is dropped. Leading only: "port" in "port forwarding" is the subject.
+declare -p TITLE_LEAD_VERBS >/dev/null 2>&1 || TITLE_LEAD_VERBS=(review adjust add fix update
+  create make check investigate debug refactor implement write set setup configure explore
+  improve build test run clean remove delete migrate port rename draft plan research diagnose audit)
+
+# Words dropped wherever they appear. A tab label is not a sentence, so articles,
+# prepositions and phrasal-verb particles only spend the budget.
+declare -p TITLE_FILLER_WORDS >/dev/null 2>&1 || TITLE_FILLER_WORDS=(a an the to for of on in at
+  and or with from into via why how what that if whether is are be it its this up out off down over back)
+
+# What joins the surviving words. The default fuses the label into one token, the
+# shape every other tab name has; " " reads as the phrase instead. Its length is
+# charged to MAX_TITLE_LEN like any other character.
+: "${TITLE_WORD_SEPARATOR:=-}"
+
+# Casing. "fold" downcases every word except an all-caps-and-digits identifier: a
+# sentence-case capital is the agent writing a sentence rather than signal, while
+# the shape of "ETL" carries meaning. "lower" folds the identifiers too, and
+# "keep" leaves the agent's casing alone.
+: "${TITLE_CASE:=fold}"
+
 # Exact program-name renames: "<program>=<label>" pairs. A matching foreground
 # program is shown as <label> regardless of its category (e.g. "clx=hn" makes a
 # clx tab read "hn"). Takes priority over every rule except the bare-prompt shell
@@ -566,6 +602,77 @@ ar_title_ignore_fold() {
   done
 }
 
+
+# ar_condense_title <title> [<reserved>] -> a task label, or "".
+#
+# The label fits MAX_TITLE_LEN minus <reserved>'s length: the caller passes the
+# literal text that will share the label (a name part and its joint, a glyph
+# and its space), and jq measures it in codepoints, because bash's ${#} counts
+# bytes under a C locale and would overcharge anything non-ASCII.
+#
+# Selects; never generates. The agent already wrote the summary, so the work here
+# is only to shorten it: drop a leading verb (TITLE_LEAD_VERBS), drop filler
+# (TITLE_FILLER_WORDS), then take whole words from the front until the budget is
+# spent, stopping at the first word that does not fit rather than skipping ahead
+# (a later short word would read as a non sequitur next to the ones before it).
+#
+# Words are taken in the order the agent wrote them. Selecting by "distinctness"
+# instead -- proper nouns, gerunds, rare words -- measurably reads worse: it
+# prefers where the work happens over what it is ("screensaver Ubuntu" for
+# "Adjust screensaver timeout on the Ubuntu box"), and an -ing word in these
+# summaries is usually a modifier ("streaming pipeline"), so promoting it evicts
+# the noun carrying the meaning. The input is already ordered by an agent that
+# put the salient words first; this trusts that rather than re-ranking it.
+#
+# One jq program rather than a bash loop: jq is already a hard dependency, reads
+# UTF-8 regardless of the ambient locale (see the truncation note in ar_format),
+# and keeps this a single subprocess per tab.
+ar_condense_title() {
+  local title=$1 reserved=${2:-} max=${MAX_TITLE_LEN:-28}
+  [ -n "$title" ] || return 0
+  printf '%s' "$title" | jq -Rrs \
+    --argjson max "$max" \
+    --arg reserved "$reserved" \
+    --arg sep "${TITLE_WORD_SEPARATOR:--}" \
+    --arg case "${TITLE_CASE:-fold}" \
+    --arg verbs "${TITLE_LEAD_VERBS[*]}" \
+    --arg filler "${TITLE_FILLER_WORDS[*]}" '
+      ([$max - ($reserved | length), 0] | max) as $m
+    | ($verbs  | ascii_downcase | split(" ")) as $verb
+    | ($filler | ascii_downcase | split(" ")) as $fill
+    # Leading state glyphs: herdr strips some agent title decorations but not
+    # all, and a label must not open with a stray bullet. Separators inside the
+    # title are word breaks, not characters ("tab/workspace" is two words).
+    | sub("^[^\\p{L}\\p{N}]+"; "")
+    # An agent that badges its title ("OC | Reviewing unpushed commits") spends
+    # the budget on its own name before saying anything. Drop a short all-caps
+    # token followed by a pipe: that shape is branding, and the cap plus the
+    # upper-case requirement keeps it off real content ("auth | login flow"
+    # keeps its first word).
+    | sub("^[A-Z0-9]{1,4} *\\| *"; "")
+    | gsub("[/,;:|]+"; " ")
+    | [splits("[[:space:]]+")]
+    | map(select(length > 0))
+    | . as $words
+    | (if ($words | length) > 0 and ($verb | index($words[0] | ascii_downcase))
+       then $words[1:] else $words end)
+    | map(. as $w | select($fill | index($w | ascii_downcase) | not))
+    # Casing: a sentence-case capital is the agent writing a sentence, not
+    # signal; an all-caps-and-digits token is an identifier whose shape means
+    # something. "fold" spares only the identifiers, "lower" folds those too,
+    # "keep" touches nothing. Anything else behaves as the "fold" default.
+    | map(if $case == "keep" then .
+          elif $case == "lower" then ascii_downcase
+          elif test("^[A-Z0-9]{2,}$") then .
+          else ascii_downcase end)
+    | reduce .[] as $w ({out: "", done: false};
+        if .done then .
+        elif .out == "" then {out: ($w[:$m]), done: false}
+        elif ((.out | length) + ($sep | length) + ($w | length)) <= $m then {out: (.out + $sep + $w), done: false}
+        else {out: .out, done: true} end)
+    | .out
+  ' 2>/dev/null
+}
 # ---- helpers ----
 
 # ssh options whose value is a SEPARATE argument, so `ssh -p 2222 prod-01` does

--- a/naming.sh
+++ b/naming.sh
@@ -185,12 +185,14 @@ declare -p TITLE_IGNORE >/dev/null 2>&1 || TITLE_IGNORE=("claude code" "codex cl
 # kinds (src/detect/mod.rs, herdr 0.8.2) and both are the same program's brand.
 #
 # opencode brands the same way with letters rather than a glyph, "OC | Reviewing
-# unpushed commits", so five of twenty columns go before the title says anything.
-# It needs no rule of its own: the entry takes "OC" off and the strip that follows
-# takes the separator, exactly as it does for a glyph. Keying it to the agent is
-# what keeps it off everyone else, where "API | authentication migration" is a
-# title somebody wrote and the badge is content.
-declare -p TITLE_BRANDS >/dev/null 2>&1 || TITLE_BRANDS=("pi="$'\317\200' "omp="$'\317\200' "opencode=OC")
+# unpushed commits", and an "opencode=OC" entry does strip it. It is deliberately
+# NOT in the default here. debrand takes a brand off wherever a non-alphanumeric
+# or the end of the string follows it, matching ASCII case-insensitively, which is
+# wider than a badge before a pipe: it also takes "OC" off "OC-192 incident" and
+# "oc" off "oc | access policy". That is a judgement about opencode titles for
+# this project to make, and making it here would change what a tab reads for
+# somebody who never turned condensing on.
+declare -p TITLE_BRANDS >/dev/null 2>&1 || TITLE_BRANDS=("pi="$'\317\200' "omp="$'\317\200')
 
 # 1 = condense a title into its keywords before it becomes a label, instead of
 # showing the agent's sentence with the tail cut off. A title arrives as prose
@@ -209,13 +211,26 @@ declare -p TITLE_BRANDS >/dev/null 2>&1 || TITLE_BRANDS=("pi="$'\317\200' "omp="
 # spends its first word saying what the tab beside it also says, so a LEADING one
 # is dropped. Leading only, so "the auth rewrite needs review" keeps its "review".
 #
-# Measured rather than imagined, against 65 titles Claude Code wrote across 1800
-# real sessions: the list fires on 26 of them, and 21 of those 26 get a content
-# word back in the same budget. No two of the 65 condense to the same label with
-# the list on OR off, so the drop buys information without costing distinctness.
-# "analyze" came out of that count as the most frequent opener not yet listed;
-# "troubleshoot", "optimize" and "show" came out of the same tail. "port" came
-# OUT of the list, being a noun far more often than a verb here.
+# Measured rather than imagined. The corpus is every title Claude Code generated
+# on one machine over three weeks: 65 of them. It is not a sample of the 1800
+# transcripts there, which are mostly headless "sdk-cli" runs and subagents that
+# are never titled; interactive sessions are titled, and an interactive session
+# is the only kind that occupies a tab.
+#
+# THIS list fires on 36 of the 65, and 31 of those get a content word back inside
+# the same budget. No two of the 65 condense to the same label with the list on or
+# off, so the drop buys information without costing distinctness. "analyze" was
+# the most frequent opener the first hand-written list had missed, seven of the
+# 65; "troubleshoot", "optimize" and "show" one each.
+#
+# "port" was taken OUT on judgement, not on evidence: the word appears nowhere in
+# these 65, so this corpus says nothing either way. It reads as a noun far more
+# often than a verb in the work these titles describe.
+#
+# One population is NOT measured here. Where an agent never titled its session,
+# the engine condenses the first prompt the user typed instead, and those are
+# phrased differently from a title an agent wrote. On this machine that group is
+# all headless automation, so it could not be sampled.
 #
 # The list matches spelling, not part of speech, so a title whose subject shares
 # a verb's spelling loses it. The failure that matters is two tabs colliding:
@@ -633,12 +648,19 @@ ar_title_ignore_fold() {
 # and its space), and jq measures it in codepoints, because bash's ${#} counts
 # bytes under a C locale and would overcharge anything non-ASCII.
 #
-# Selects; never generates, with one bounded exception: a single word longer than
-# the whole budget is cut, because dropping it would empty the label and hand the
-# tab back the untouched sentence. That cut is the same one ar_format would make
-# on the sentence a moment later, so the label is identical either way and the
-# exception costs nothing. The agent already wrote the summary, so the work here
-# is only to shorten it: drop a leading verb (TITLE_LEAD_VERBS), drop filler
+# Selects; never generates, with one exception: the FIRST surviving word, when it
+# alone is longer than the budget, is cut rather than dropped, and the cut lands
+# on a codepoint rather than a grapheme, so a word ending in a combining mark or a
+# ZWJ sequence can be left dangling. Dropping it instead would empty the label and
+# hand the tab the untouched sentence.
+#
+# The two are NOT the same label. The sentence keeps the words this function drops
+# and the casing it folds, so "Investigate Supercalifragilisticexpialidocious
+# tail" reaches a 19-character tab as "supercalifragilisti" here and as
+# "Investigate" through the fallback. Which reads better is a judgement; that they
+# differ is not, and an earlier note claiming they were identical was wrong.
+#
+# The agent already wrote the summary, so the work here is only to shorten it: drop a leading verb (TITLE_LEAD_VERBS), drop filler
 # (TITLE_FILLER_WORDS), then take whole words from the front until the budget is
 # spent, stopping at the first word that does not fit rather than skipping ahead
 # (a later short word would read as a non sequitur next to the ones before it).
@@ -681,7 +703,14 @@ ar_condense_title() {
     | . as $words
     | (if ($words | length) > 0 and ($verb | index($words[0] | ascii_downcase))
        then $words[1:] else $words end)
-    | map(. as $w | select($fill | index($w | ascii_downcase) | not))
+    # An all-caps token is an identifier, and the casing rule below spares it for
+    # exactly that reason. Filler is matched case-insensitively, so without this
+    # the two rules disagree and the identifier loses: "Investigate IT outage"
+    # became "outage" and "Fix OR parser precedence" became "parser-precedence",
+    # because "it" and "or" are filler. The same {2,} test as the casing rule, so
+    # the two cannot drift; a one-letter identifier is not covered, and the only
+    # single letter in the default filler list is "a".
+    | map(. as $w | select(($w | test("^[A-Z0-9]{2,}$")) or ($fill | index($w | ascii_downcase) | not)))
     # Casing: a sentence-case capital is the agent writing a sentence, not
     # signal; an all-caps-and-digits token is an identifier whose shape means
     # something. "fold" spares only the identifiers, "lower" folds those too,

--- a/naming.sh
+++ b/naming.sh
@@ -183,7 +183,14 @@ declare -p TITLE_IGNORE >/dev/null 2>&1 || TITLE_IGNORE=("claude code" "codex cl
 # for the reason icons.sh writes its glyphs that way: a literal one is what an
 # editor eats without saying so. "pi" and "omp" are both canonical herdr agent
 # kinds (src/detect/mod.rs, herdr 0.8.2) and both are the same program's brand.
-declare -p TITLE_BRANDS >/dev/null 2>&1 || TITLE_BRANDS=("pi="$'\317\200' "omp="$'\317\200')
+#
+# opencode brands the same way with letters rather than a glyph, "OC | Reviewing
+# unpushed commits", so five of twenty columns go before the title says anything.
+# It needs no rule of its own: the entry takes "OC" off and the strip that follows
+# takes the separator, exactly as it does for a glyph. Keying it to the agent is
+# what keeps it off everyone else, where "API | authentication migration" is a
+# title somebody wrote and the badge is content.
+declare -p TITLE_BRANDS >/dev/null 2>&1 || TITLE_BRANDS=("pi="$'\317\200' "omp="$'\317\200' "opencode=OC")
 
 # 1 = condense a title into its keywords before it becomes a label, instead of
 # showing the agent's sentence with the tail cut off. A title arrives as prose
@@ -200,10 +207,26 @@ declare -p TITLE_BRANDS >/dev/null 2>&1 || TITLE_BRANDS=("pi="$'\317\200' "omp="
 
 # Verbs an agent opens a title with. Every tab reading "Fix ..." or "Add ..."
 # spends its first word saying what the tab beside it also says, so a LEADING one
-# is dropped. Leading only: "port" in "port forwarding" is the subject.
+# is dropped. Leading only, so "the auth rewrite needs review" keeps its "review".
+#
+# Measured rather than imagined, against 65 titles Claude Code wrote across 1800
+# real sessions: the list fires on 26 of them, and 21 of those 26 get a content
+# word back in the same budget. No two of the 65 condense to the same label with
+# the list on OR off, so the drop buys information without costing distinctness.
+# "analyze" came out of that count as the most frequent opener not yet listed;
+# "troubleshoot", "optimize" and "show" came out of the same tail. "port" came
+# OUT of the list, being a noun far more often than a verb here.
+#
+# The list matches spelling, not part of speech, so a title whose subject shares
+# a verb's spelling loses it. The failure that matters is two tabs colliding:
+# "Review flashcard generation" and "Implement flashcard generation" both reduce
+# to "flashcard-generation". It did not happen across those 65, but the corpus is
+# one person and one agent, which is the argument for a knob rather than a
+# constant. TITLE_LEAD_VERBS=() turns the rule off.
 declare -p TITLE_LEAD_VERBS >/dev/null 2>&1 || TITLE_LEAD_VERBS=(review adjust add fix update
   create make check investigate debug refactor implement write set setup configure explore
-  improve build test run clean remove delete migrate port rename draft plan research diagnose audit)
+  improve build test run clean remove delete migrate rename draft plan research diagnose audit
+  analyze troubleshoot optimize show)
 
 # Words dropped wherever they appear. A tab label is not a sentence, so articles,
 # prepositions and phrasal-verb particles only spend the budget.
@@ -610,7 +633,11 @@ ar_title_ignore_fold() {
 # and its space), and jq measures it in codepoints, because bash's ${#} counts
 # bytes under a C locale and would overcharge anything non-ASCII.
 #
-# Selects; never generates. The agent already wrote the summary, so the work here
+# Selects; never generates, with one bounded exception: a single word longer than
+# the whole budget is cut, because dropping it would empty the label and hand the
+# tab back the untouched sentence. That cut is the same one ar_format would make
+# on the sentence a moment later, so the label is identical either way and the
+# exception costs nothing. The agent already wrote the summary, so the work here
 # is only to shorten it: drop a leading verb (TITLE_LEAD_VERBS), drop filler
 # (TITLE_FILLER_WORDS), then take whole words from the front until the budget is
 # spent, stopping at the first word that does not fit rather than skipping ahead
@@ -640,16 +667,14 @@ ar_condense_title() {
       ([$max - ($reserved | length), 0] | max) as $m
     | ($verbs  | ascii_downcase | split(" ")) as $verb
     | ($filler | ascii_downcase | split(" ")) as $fill
-    # Leading state glyphs: herdr strips some agent title decorations but not
-    # all, and a label must not open with a stray bullet. Separators inside the
-    # title are word breaks, not characters ("tab/workspace" is two words).
-    | sub("^[^\\p{L}\\p{N}]+"; "")
-    # An agent that badges its title ("OC | Reviewing unpushed commits") spends
-    # the budget on its own name before saying anything. Drop a short all-caps
-    # token followed by a pipe: that shape is branding, and the cap plus the
-    # upper-case requirement keeps it off real content ("auth | login flow"
-    # keeps its first word).
-    | sub("^[A-Z0-9]{1,4} *\\| *"; "")
+    # Separators inside the title are word breaks, not characters, so
+    # "tab/workspace" is two words rather than one long one.
+    #
+    # Nothing strips a leading glyph or a leading brand here, though both reach
+    # a title: the engine has already run lead and debrand, the two definitions
+    # in AR_JQ_TASK, on every path that arrives here, which is the two pane lifts
+    # and both transcript reads. Doing either again would be a second copy of a
+    # rule upstream owns, free to drift from it and answering to no test.
     | gsub("[/,;:|]+"; " ")
     | [splits("[[:space:]]+")]
     | map(select(length > 0))

--- a/tests/test_condense.sh
+++ b/tests/test_condense.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# Tests for TITLE_CONDENSE -- the keyword condensation layered on AGENT_TITLES.
+#
+# Two halves. The first is pure string in / string out against ar_condense_title,
+# the way tests/test_naming.sh tests the rest of naming.sh. The second drives the
+# real engine against the fake herdr, because the knob is only worth anything if
+# it sits in the title path the reconcile actually walks, and a unit test cannot
+# say whether it was wired in at all.
+#
+# This file is deliberately separate from the released suites rather than folded
+# into them: TITLE_CONDENSE defaults to off, so every released expectation still
+# describes the shipped behavior, and nothing here has to be re-resolved when
+# those files change upstream.
+
+set -o pipefail
+here=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/lib.sh
+. "$here/lib.sh"
+
+SHELL_NAME=zsh
+# shellcheck source=naming.sh
+. "$here/../naming.sh"
+
+# ---- what gets dropped ----
+check "leading verb goes" "screensaver-timeout" \
+  "$(ar_condense_title 'Adjust the screensaver timeout')"
+check "filler goes throughout" "nightly-ETL-job-drops-rows" \
+  "$(ar_condense_title 'Investigate why the nightly ETL job drops rows')"
+# The list matches spelling, not part of speech, and the leading position is
+# where that bites: "port" is the subject here and is dropped anyway. Taking the
+# word out of TITLE_LEAD_VERBS is the answer where a title needs it.
+check "a leading list word goes, verb or not" "forwarding-broken" \
+  "$(ar_condense_title 'Port forwarding is broken')"
+check "and dropping it from the list restores it" "port-forwarding-broken" \
+  "$(TITLE_LEAD_VERBS=(review adjust fix); ar_condense_title 'Port forwarding is broken')"
+check "a non-leading verb stays" "auth-rewrite-needs-review" \
+  "$(ar_condense_title 'The auth rewrite needs review')"
+
+# The order the agent wrote is the order kept: it put the salient words first,
+# and re-ranking them by "distinctness" reads worse (see the note on the function).
+check "word order is preserved" "RFC7-wording-clarity" \
+  "$(ar_condense_title 'Review RFC7 wording for clarity')"
+
+# ---- separators inside the title are word breaks ----
+check "slash is a word break" "build-services-payments" \
+  "$(ar_condense_title 'Fix build for services/payments')"
+check "colon is a word break" "ADR-0028-step-3" \
+  "$(ar_condense_title 'ADR 0028: step 3')"
+
+# ---- an agent that badges its own title ----
+# opencode writes "OC | <task>". A short all-caps token before a pipe is the
+# agent naming itself and spends the budget saying nothing.
+check "a badge is dropped" "reviewing-unpushed-commits" \
+  "$(ar_condense_title 'OC | Reviewing unpushed commits')"
+check "real content keeps its first word" "auth-login-flow" \
+  "$(ar_condense_title 'auth | login flow')"
+
+# ---- leading decoration ----
+# The engine strips the spinner before ar_title_clean, but a title can lead with
+# punctuation the strip does not reach, and a label must not open with one.
+check "leading punctuation goes" "parser-rewrite" \
+  "$(ar_condense_title '>>> Parser rewrite')"
+
+# ---- casing ----
+check "fold spares an identifier" "RFC7-wording-clarity" \
+  "$(TITLE_CASE='fold' ar_condense_title 'Review RFC7 wording for clarity')"
+check "lower folds it too" "rfc7-wording-clarity" \
+  "$(TITLE_CASE='lower' ar_condense_title 'Review RFC7 wording for clarity')"
+check "keep leaves the agent's casing" "RFC7-Wording-Clarity" \
+  "$(TITLE_CASE='keep' ar_condense_title 'Review RFC7 Wording For Clarity')"
+check "an unknown case behaves as fold" "RFC7-wording-clarity" \
+  "$(TITLE_CASE='sideways' ar_condense_title 'Review RFC7 wording for clarity')"
+
+# ---- separator ----
+check "the separator is configurable" "screensaver timeout" \
+  "$(TITLE_WORD_SEPARATOR=' ' ar_condense_title 'Adjust the screensaver timeout')"
+check "and is charged to the budget" "nightly_ETL_job_drops" \
+  "$(TITLE_WORD_SEPARATOR=_ MAX_TITLE_LEN=24 ar_condense_title 'Investigate why the nightly ETL job drops rows')"
+
+# ---- the budget ----
+# Whole words only, and it stops at the first that does not fit rather than
+# skipping ahead to a shorter one: a later word reads as a non sequitur beside
+# the ones before it.
+check "stops at the first word that does not fit" "nightly-ETL-pipeline" \
+  "$(MAX_TITLE_LEN=24 ar_condense_title 'Investigate why the nightly ETL pipeline drops duplicate rows')"
+check "reserved text comes out of the budget" "nightly-ETL" \
+  "$(MAX_TITLE_LEN=24 ar_condense_title 'Investigate why the nightly ETL pipeline drops duplicate rows' '            ')"
+# A single word longer than the whole budget is cut rather than dropped, or the
+# label would be empty and the sentence would come back instead.
+check "an oversized lone word is cut" "supercalifragilisti" \
+  "$(MAX_TITLE_LEN=19 ar_condense_title 'supercalifragilisticexpialidocious')"
+
+# The budget is codepoints, not bytes. herdr may launch a plugin with no LC_*,
+# where bash counts bytes and would cut a multibyte character in half. Counted as
+# bytes this label stops after "funf" (5 bytes + 6 for the next word exceeds 11);
+# counted as codepoints both words fit.
+#
+# The capital survives because the fold is ascii_downcase, which is jq's only
+# case operation: its character CLASSES know Unicode, its case conversion does
+# not. A non-ASCII capital therefore reaches the label as the agent wrote it.
+check "the budget counts codepoints" "$(printf 'f\303\274nf-\303\204pfel')" \
+  "$(LC_ALL=C MAX_TITLE_LEN=11 ar_condense_title "$(printf 'F\303\274nf \303\204pfel gefunden')")"
+
+# ---- nothing to say ----
+check "an empty title condenses to nothing" "" "$(ar_condense_title '')"
+# All filler condenses to nothing, and the caller keeps the sentence rather than
+# renaming the tab to an empty string.
+check "an all-filler title condenses to nothing" "" "$(ar_condense_title 'to the of')"
+
+# ======================================================================
+# End to end: the real engine, the fake herdr, TITLE_CONDENSE=1.
+# ======================================================================
+ENGINE="$here/../automatic-rename.sh"
+MOCK="$here/mocks/herdr"
+chmod +x "$MOCK" 2>/dev/null || true
+
+setup() {
+  SB=$(mktemp -d "${TMPDIR:-/tmp}/hal-condense.XXXXXX")
+  export HERDR_MOCK_DIR="$SB/fixtures"; mkdir -p "$HERDR_MOCK_DIR"
+  export HERDR_MOCK_LOG="$SB/renames.log"; : >"$HERDR_MOCK_LOG"
+  export HERDR_BIN_PATH="$MOCK"
+  export XDG_STATE_HOME="$SB/state"
+  export HERDR_AUTOMATIC_RENAME_CONFIG="$SB/none.sh"
+  export HERDR_CONFIG_FILE="$SB/herdr.toml"
+  printf 'agent_panel_sort = "spaces"\n' >"$HERDR_CONFIG_FILE"
+  export HERDR_SOCKET_PATH="$SB/herdr.sock"
+  export SHELL_NAME=zsh
+  # A suite run from inside a live herdr pane inherits these, and a tab id no
+  # fixture describes would reach the real session.
+  unset HERDR_TAB_ID HERDR_PLUGIN_CONTEXT_JSON
+  unset HERDR_MOCK_VERSION HERDR_MOCK_NO_VERSION HIDE_SHELL
+  unset AUTO_INDEX_WORKSPACES AUTO_INDEX_TABS AUTO_INDEX_AGENTS
+}
+fixture() { cat >"$HERDR_MOCK_DIR/$1"; }
+run_event() { /usr/bin/env bash "$ENGINE" "$1"; }
+log() { cat "$HERDR_MOCK_LOG"; }
+teardown() { rm -rf "$SB" 2>/dev/null || true; }
+
+# ----------------------------------------------------------------------
+# t1 is the ordinary case, spinner glyph included: the engine strips it, the
+#    condensation gets prose, the tab gets keywords.
+# t2 is a refusal. "Claude Code" never reaches the condensation at all, and the
+#    tab falls back to the program name, exactly as with the knob off.
+# t3 ships no procinfo fixture, so the mock serves "{}" and no program name can
+#    be computed. A label here can only have come through the title path, which
+#    is what pins the wiring rather than the function.
+# ----------------------------------------------------------------------
+setup
+export NAME_TABS=1 AUTO_INDEX=0 TITLE_CONDENSE=1
+fixture workspaces.json <<'JSON'
+{"result":{"workspaces":[{"workspace_id":"w1","label":"api"}]}}
+JSON
+fixture tabs_w1.json <<'JSON'
+{"result":{"tabs":[
+  {"tab_id":"w1:t1","label":"1","pane_count":1,"focused":true},
+  {"tab_id":"w1:t2","label":"2","pane_count":1,"focused":false},
+  {"tab_id":"w1:t3","label":"3","pane_count":1,"focused":false}
+]}}
+JSON
+fixture panes.json <<'JSON'
+{"result":{"panes":[
+  {"pane_id":"p1","tab_id":"w1:t1","focused":true,"agent":"claude","agent_status":"working",
+   "terminal_title_stripped":"✳ Squash merge command","foreground_cwd":"/home/u/dev/api"},
+  {"pane_id":"p2","tab_id":"w1:t2","focused":false,"agent":"claude","agent_status":"idle",
+   "terminal_title_stripped":"Claude Code","foreground_cwd":"/home/u/dev/api"},
+  {"pane_id":"p3","tab_id":"w1:t3","focused":false,"agent":"claude","agent_status":"working",
+   "terminal_title_stripped":"Investigate why the nightly ETL job drops rows",
+   "foreground_cwd":"/home/u/dev/api"}
+]}}
+JSON
+fixture procinfo_p1.json <<'JSON'
+{"result":{"process_info":{"foreground_process_group_id":1,
+  "foreground_processes":[{"pid":1,"argv0":"claude","cmdline":"claude"}]}}}
+JSON
+fixture procinfo_p2.json <<'JSON'
+{"result":{"process_info":{"foreground_process_group_id":2,
+  "foreground_processes":[{"pid":2,"argv0":"claude","cmdline":"claude"}]}}}
+JSON
+out=$(run_event tab.created >/dev/null 2>&1; log)
+check_contains "the title is condensed onto the tab" "$out" "tab rename w1:t1 squash-merge-command"
+check_absent   "the sentence never reaches herdr"    "$out" "Squash merge command"
+check_contains "a refused title still falls back"    "$out" "tab rename w1:t2 claude"
+check_absent   "and is not condensed either"         "$out" "claude-code"
+check_contains "a title needs no process lookup"     "$out" "tab rename w1:t3 nightly-ETL-job-drops-rows"
+teardown
+
+# ----------------------------------------------------------------------
+# The knob is off unless asked for: the same fixtures, no TITLE_CONDENSE, and
+# the label is the sentence the released plugin has always written.
+# ----------------------------------------------------------------------
+setup
+export NAME_TABS=1 AUTO_INDEX=0
+unset TITLE_CONDENSE
+fixture workspaces.json <<'JSON'
+{"result":{"workspaces":[{"workspace_id":"w1","label":"api"}]}}
+JSON
+fixture tabs_w1.json <<'JSON'
+{"result":{"tabs":[{"tab_id":"w1:t1","label":"1","pane_count":1,"focused":true}]}}
+JSON
+fixture panes.json <<'JSON'
+{"result":{"panes":[
+  {"pane_id":"p1","tab_id":"w1:t1","focused":true,"agent":"claude","agent_status":"working",
+   "terminal_title_stripped":"Squash merge command","foreground_cwd":"/home/u/dev/api"}
+]}}
+JSON
+out=$(run_event tab.created >/dev/null 2>&1; log)
+check_contains "off by default: the sentence survives" "$out" "tab rename w1:t1 Squash merge command"
+teardown
+
+# ----------------------------------------------------------------------
+# The glyph and its space are prepended before ar_format truncates, so they come
+# out of the same budget. Unreserved, a full-length label loses its tail to make
+# room for them. MAX_NAME_LEN=20 puts MAX_TITLE_LEN at 28.
+# ----------------------------------------------------------------------
+setup
+export NAME_TABS=1 AUTO_INDEX=0 TITLE_CONDENSE=1 ICONS_ENABLED=1
+fixture workspaces.json <<'JSON'
+{"result":{"workspaces":[{"workspace_id":"w1","label":"api"}]}}
+JSON
+fixture tabs_w1.json <<'JSON'
+{"result":{"tabs":[{"tab_id":"w1:t1","label":"1","pane_count":1,"focused":true}]}}
+JSON
+fixture panes.json <<'JSON'
+{"result":{"panes":[
+  {"pane_id":"p1","tab_id":"w1:t1","focused":true,"agent":"claude","agent_status":"working",
+   "terminal_title_stripped":"Investigate why the nightly ETL job drops rows",
+   "foreground_cwd":"/home/u/dev/api"}
+]}}
+JSON
+out=$(run_event tab.created >/dev/null 2>&1; log)
+# Two fewer characters than the glyphless label above: "drops-rows" no longer fits.
+check_contains "the glyph is reserved out of the budget" "$out" "nightly-ETL-job-drops"
+check_absent   "so nothing is cut off the end"           "$out" "drops-row "
+teardown
+
+t_summary

--- a/tests/test_condense.sh
+++ b/tests/test_condense.sh
@@ -73,6 +73,16 @@ check "nor is leading punctuation" ">>>-parser-rewrite" \
 check "a pipe is a word break" "auth-login-flow" \
   "$(ar_condense_title 'auth | login flow')"
 
+# ---- an all-caps identifier is not filler ----
+# Filler is matched case-insensitively and the casing rule spares all-caps tokens,
+# so without an exemption the two disagree and the identifier is the one that goes.
+check "IT survives the filler list" "IT-outage" \
+  "$(ar_condense_title 'Investigate IT outage')"
+check "OR survives it too" "OR-parser-precedence" \
+  "$(ar_condense_title 'Fix OR parser precedence')"
+check "lowercase filler still goes" "screensaver-timeout" \
+  "$(ar_condense_title 'Adjust the screensaver timeout')"
+
 # ---- casing ----
 check "fold spares an identifier" "RFC7-wording-clarity" \
   "$(TITLE_CASE='fold' ar_condense_title 'Review RFC7 wording for clarity')"
@@ -286,9 +296,15 @@ fixture panes.json <<'JSON'
 ]}}
 JSON
 out=$(run_event tab.created >/dev/null 2>&1; log)
-check_contains "a wide glyph is reserved whole"  "$out" "XYZZ nightly-ETL-job-drops"
-check_absent   "so no word is cut to fit it"     "$out" "XYZZ nightly-ETL-job-drops-m"
-check_contains "no glyph reserves nothing"       "$out" "nightly-ETL-job-drops-many"
+# "XYZZ " is five, so the task gets 23 of the 28 and stops at "drops";
+# reserving two would have condensed to 26 and left ar_format to cut "many" in
+# half. The whole label is asserted, not a prefix of it: a substring check here
+# passes on any longer cut and proves nothing about where the budget landed.
+check_contains "a wide glyph is reserved whole"  "$out" "tab rename w1:t1 XYZZ nightly-ETL-job-drops"
+# Anchored to the tab: the log carries every rename, and t2 legitimately ends in
+# "drops-many", so a bare needle matches the correct label on the other tab.
+check_absent   "and the word after it is gone"   "$out" "w1:t1 XYZZ nightly-ETL-job-drops-man"
+check_contains "no glyph reserves nothing"       "$out" "tab rename w1:t2 nightly-ETL-job-drops-many"
 teardown
 
 # ----------------------------------------------------------------------
@@ -299,6 +315,10 @@ teardown
 # ----------------------------------------------------------------------
 setup
 export NAME_TABS=1 AUTO_INDEX=0 TITLE_CONDENSE=1
+cat >"$SB/cfg.sh" <<'CFG'
+TITLE_BRANDS=("opencode=OC")
+CFG
+export HERDR_AUTOMATIC_RENAME_CONFIG="$SB/cfg.sh"
 fixture workspaces.json <<'JSON'
 {"result":{"workspaces":[{"workspace_id":"w1","label":"api"}]}}
 JSON
@@ -317,9 +337,33 @@ fixture panes.json <<'JSON'
 ]}}
 JSON
 out=$(run_event tab.created >/dev/null 2>&1; log)
-check_contains "the agent brand comes off"       "$out" "tab rename w1:t1 reviewing-unpushed-commits"
+check_contains "a configured brand comes off"    "$out" "tab rename w1:t1 reviewing-unpushed-commits"
 check_absent   "and does not reach the tab"      "$out" "OC-reviewing"
 check_contains "another agent keeps those chars" "$out" "tab rename w1:t2 API-authentication-migration"
+teardown
+
+# ----------------------------------------------------------------------
+# And the default carries no opencode entry, so the badge stays. Deleting our own
+# badge rule cost this, and the entry that would restore it is wider than the
+# rule was: it would also take "OC" off "OC-192 incident", for somebody who never
+# asked for condensing at all.
+# ----------------------------------------------------------------------
+setup
+export NAME_TABS=1 AUTO_INDEX=0 TITLE_CONDENSE=1
+fixture workspaces.json <<'JSON'
+{"result":{"workspaces":[{"workspace_id":"w1","label":"api"}]}}
+JSON
+fixture tabs_w1.json <<'JSON'
+{"result":{"tabs":[{"tab_id":"w1:t1","label":"1","pane_count":1,"focused":true}]}}
+JSON
+fixture panes.json <<'JSON'
+{"result":{"panes":[
+  {"pane_id":"p1","tab_id":"w1:t1","focused":true,"agent":"opencode","agent_status":"working",
+   "terminal_title_stripped":"OC | Reviewing unpushed commits","foreground_cwd":"/home/u/dev/api"}
+]}}
+JSON
+out=$(run_event tab.created >/dev/null 2>&1; log)
+check_contains "unconfigured, the badge stays"   "$out" "tab rename w1:t1 OC-reviewing-unpushed"
 teardown
 
 t_summary

--- a/tests/test_condense.sh
+++ b/tests/test_condense.sh
@@ -26,13 +26,24 @@ check "leading verb goes" "screensaver-timeout" \
   "$(ar_condense_title 'Adjust the screensaver timeout')"
 check "filler goes throughout" "nightly-ETL-job-drops-rows" \
   "$(ar_condense_title 'Investigate why the nightly ETL job drops rows')"
-# The list matches spelling, not part of speech, and the leading position is
-# where that bites: "port" is the subject here and is dropped anyway. Taking the
-# word out of TITLE_LEAD_VERBS is the answer where a title needs it.
-check "a leading list word goes, verb or not" "forwarding-broken" \
+# "port" is not in the list: measured against real titles it is a noun far more
+# often than a verb here, and the leading position is exactly where that bites.
+check "port is a subject, not a verb" "port-forwarding-broken" \
   "$(ar_condense_title 'Port forwarding is broken')"
-check "and dropping it from the list restores it" "port-forwarding-broken" \
-  "$(TITLE_LEAD_VERBS=(review adjust fix); ar_condense_title 'Port forwarding is broken')"
+
+# The list still matches spelling rather than part of speech, which is a real
+# limit and not a bug to be fixed by lengthening the list. A title whose subject
+# shares a listed verb spelling loses it, and taking the word out is the answer.
+check "a listed spelling goes, verb or not" "needs-approval" \
+  "$(ar_condense_title 'Plan needs approval')"
+check "and dropping it from the list restores it" "plan-needs-approval" \
+  "$(TITLE_LEAD_VERBS=(review adjust fix); ar_condense_title 'Plan needs approval')"
+
+# The openers the corpus turned up that the hand-written list had missed.
+check "analyze is a lead verb" "flashcard-pipeline-latency" \
+  "$(ar_condense_title 'Analyze flashcard pipeline latency')"
+check "troubleshoot is a lead verb" "waybar-restart-loop" \
+  "$(ar_condense_title 'Troubleshoot the Waybar restart loop')"
 check "a non-leading verb stays" "auth-rewrite-needs-review" \
   "$(ar_condense_title 'The auth rewrite needs review')"
 
@@ -47,19 +58,20 @@ check "slash is a word break" "build-services-payments" \
 check "colon is a word break" "ADR-0028-step-3" \
   "$(ar_condense_title 'ADR 0028: step 3')"
 
-# ---- an agent that badges its own title ----
-# opencode writes "OC | <task>". A short all-caps token before a pipe is the
-# agent naming itself and spends the budget saying nothing.
-check "a badge is dropped" "reviewing-unpushed-commits" \
+# ---- what this function deliberately does NOT do ----
+# A leading glyph and a leading brand are both taken off upstream, by lead and
+# debrand in AR_JQ_TASK, on every path that reaches here. So this function is
+# never handed either, and it strips neither: a second copy of an upstream rule
+# is free to drift from it. These two pin that contract, and the end-to-end
+# scenarios below prove the engine really does strip them before we are called.
+check "a leading brand is not ours to strip" "OC-reviewing-unpushed" \
   "$(ar_condense_title 'OC | Reviewing unpushed commits')"
-check "real content keeps its first word" "auth-login-flow" \
-  "$(ar_condense_title 'auth | login flow')"
-
-# ---- leading decoration ----
-# The engine strips the spinner before ar_title_clean, but a title can lead with
-# punctuation the strip does not reach, and a label must not open with one.
-check "leading punctuation goes" "parser-rewrite" \
+check "nor is leading punctuation" ">>>-parser-rewrite" \
   "$(ar_condense_title '>>> Parser rewrite')"
+# A pipe is still a word break, so a title that reaches us with one is split on
+# it rather than carrying it into the label.
+check "a pipe is a word break" "auth-login-flow" \
+  "$(ar_condense_title 'auth | login flow')"
 
 # ---- casing ----
 check "fold spares an identifier" "RFC7-wording-clarity" \
@@ -130,6 +142,11 @@ setup() {
   unset HERDR_TAB_ID HERDR_PLUGIN_CONTEXT_JSON
   unset HERDR_MOCK_VERSION HERDR_MOCK_NO_VERSION HIDE_SHELL
   unset AUTO_INDEX_WORKSPACES AUTO_INDEX_TABS AUTO_INDEX_AGENTS
+  # Every knob a scenario below turns on, cleared here rather than there: an
+  # export that outlives its scenario is a later one testing something it did
+  # not ask for, and it reads as a real failure in whichever runs next.
+  unset TITLE_CONDENSE ICONS_ENABLED ICON_STYLE ICON_MAP ICON_FALLBACK
+  unset MAX_TITLE_LEN MAX_NAME_LEN TITLE_WORD_SEPARATOR TITLE_CASE
 }
 fixture() { cat >"$HERDR_MOCK_DIR/$1"; }
 run_event() { /usr/bin/env bash "$ENGINE" "$1"; }
@@ -231,6 +248,78 @@ out=$(run_event tab.created >/dev/null 2>&1; log)
 # Two fewer characters than the glyphless label above: "drops-rows" no longer fits.
 check_contains "the glyph is reserved out of the budget" "$out" "nightly-ETL-job-drops"
 check_absent   "so nothing is cut off the end"           "$out" "drops-row "
+teardown
+
+# ----------------------------------------------------------------------
+# The glyph reserve, which has to be the glyph and not an allowance for one.
+# t1 ships an ICON_MAP entry four codepoints wide. Reserving a flat two would
+#    leave the label two over budget, and ar_format would cut the last word in
+#    half -- the one outcome condensing exists to prevent.
+# t2 ships a program with no glyph at all (ICON_FALLBACK empty, program off the
+#    map). Reserving anything there shortens the label to make room for nothing.
+# ----------------------------------------------------------------------
+setup
+export NAME_TABS=1 AUTO_INDEX=0 TITLE_CONDENSE=1 ICONS_ENABLED=1
+cat >"$SB/cfg.sh" <<'CFG'
+ICON_MAP=("claude=XYZZ")
+ICON_FALLBACK=""
+MAX_TITLE_LEN=28
+CFG
+export HERDR_AUTOMATIC_RENAME_CONFIG="$SB/cfg.sh"
+fixture workspaces.json <<'JSON'
+{"result":{"workspaces":[{"workspace_id":"w1","label":"api"}]}}
+JSON
+fixture tabs_w1.json <<'JSON'
+{"result":{"tabs":[
+  {"tab_id":"w1:t1","label":"1","pane_count":1,"focused":true},
+  {"tab_id":"w1:t2","label":"2","pane_count":1,"focused":false}
+]}}
+JSON
+fixture panes.json <<'JSON'
+{"result":{"panes":[
+  {"pane_id":"p1","tab_id":"w1:t1","focused":true,"agent":"claude","agent_status":"working",
+   "terminal_title_stripped":"Investigate why the nightly ETL job drops many rows",
+   "foreground_cwd":"/home/u/dev/api"},
+  {"pane_id":"p2","tab_id":"w1:t2","focused":false,"agent":"novelagent","agent_status":"working",
+   "terminal_title_stripped":"Investigate why the nightly ETL job drops many rows",
+   "foreground_cwd":"/home/u/dev/api"}
+]}}
+JSON
+out=$(run_event tab.created >/dev/null 2>&1; log)
+check_contains "a wide glyph is reserved whole"  "$out" "XYZZ nightly-ETL-job-drops"
+check_absent   "so no word is cut to fit it"     "$out" "XYZZ nightly-ETL-job-drops-m"
+check_contains "no glyph reserves nothing"       "$out" "nightly-ETL-job-drops-many"
+teardown
+
+# ----------------------------------------------------------------------
+# The brand an agent stamps on its own title comes off upstream, keyed to the
+# agent, before this ever runs. t1 is opencode, whose "OC" is in TITLE_BRANDS.
+# t2 is the same shape written by an agent that brands nothing, where those
+# characters are content somebody typed and must survive.
+# ----------------------------------------------------------------------
+setup
+export NAME_TABS=1 AUTO_INDEX=0 TITLE_CONDENSE=1
+fixture workspaces.json <<'JSON'
+{"result":{"workspaces":[{"workspace_id":"w1","label":"api"}]}}
+JSON
+fixture tabs_w1.json <<'JSON'
+{"result":{"tabs":[
+  {"tab_id":"w1:t1","label":"1","pane_count":1,"focused":true},
+  {"tab_id":"w1:t2","label":"2","pane_count":1,"focused":false}
+]}}
+JSON
+fixture panes.json <<'JSON'
+{"result":{"panes":[
+  {"pane_id":"p1","tab_id":"w1:t1","focused":true,"agent":"opencode","agent_status":"working",
+   "terminal_title_stripped":"OC | Reviewing unpushed commits","foreground_cwd":"/home/u/dev/api"},
+  {"pane_id":"p2","tab_id":"w1:t2","focused":false,"agent":"claude","agent_status":"working",
+   "terminal_title_stripped":"API | authentication migration","foreground_cwd":"/home/u/dev/api"}
+]}}
+JSON
+out=$(run_event tab.created >/dev/null 2>&1; log)
+check_contains "the agent brand comes off"       "$out" "tab rename w1:t1 reviewing-unpushed-commits"
+check_absent   "and does not reach the tab"      "$out" "OC-reviewing"
+check_contains "another agent keeps those chars" "$out" "tab rename w1:t2 API-authentication-migration"
 teardown
 
 t_summary

--- a/tests/test_condense.sh
+++ b/tests/test_condense.sh
@@ -82,6 +82,17 @@ check "OR survives it too" "OR-parser-precedence" \
   "$(ar_condense_title 'Fix OR parser precedence')"
 check "lowercase filler still goes" "screensaver-timeout" \
   "$(ar_condense_title 'Adjust the screensaver timeout')"
+# Listing the word in capitals is how you ask for it to go anyway; lower case in
+# the list does not reach an all-caps token.
+check "a capitalised entry drops it" "wording" \
+  "$(TITLE_FILLER_WORDS=(RFC the); ar_condense_title 'Fix the RFC wording')"
+check "a lowercase entry does not" "RFC-wording" \
+  "$(TITLE_FILLER_WORDS=(rfc the); ar_condense_title 'Fix the RFC wording')"
+# Two documented costs of the rule, pinned so they are noticed if they change.
+check "shouted prose keeps its capitals" "THE-parser" \
+  "$(ar_condense_title 'Fix THE parser')"
+check "a one-letter identifier is not covered" "record-resolution" \
+  "$(ar_condense_title 'Fix A record resolution')"
 
 # ---- casing ----
 check "fold spares an identifier" "RFC7-wording-clarity" \
@@ -158,6 +169,18 @@ setup() {
   unset TITLE_CONDENSE ICONS_ENABLED ICON_STYLE ICON_MAP ICON_FALLBACK
   unset MAX_TITLE_LEN MAX_NAME_LEN TITLE_WORD_SEPARATOR TITLE_CASE
 }
+# check_rename <name> <log> <tab id> <the WHOLE label>
+#
+# check_contains is a substring test, and every assertion here that mattered was
+# written with it: a check for "XYZZ nightly-ETL-job-drops" passes just as well on
+# a broken "XYZZ nightly-ETL-job-drops-m", so the tests written to catch a budget
+# off by two characters all passed against the bug they were written for. This
+# compares the label whole.
+check_rename() {
+  local want="tab rename $3 $4" got
+  got=$(printf '%s\n' "$2" | grep -F "tab rename $3 " | head -1)
+  check "$1" "$want" "$got"
+}
 fixture() { cat >"$HERDR_MOCK_DIR/$1"; }
 run_event() { /usr/bin/env bash "$ENGINE" "$1"; }
 log() { cat "$HERDR_MOCK_LOG"; }
@@ -204,11 +227,11 @@ fixture procinfo_p2.json <<'JSON'
   "foreground_processes":[{"pid":2,"argv0":"claude","cmdline":"claude"}]}}}
 JSON
 out=$(run_event tab.created >/dev/null 2>&1; log)
-check_contains "the title is condensed onto the tab" "$out" "tab rename w1:t1 squash-merge-command"
+check_rename   "the title is condensed onto the tab" "$out" w1:t1 "squash-merge-command"
 check_absent   "the sentence never reaches herdr"    "$out" "Squash merge command"
-check_contains "a refused title still falls back"    "$out" "tab rename w1:t2 claude"
+check_rename   "a refused title still falls back"    "$out" w1:t2 "claude"
 check_absent   "and is not condensed either"         "$out" "claude-code"
-check_contains "a title needs no process lookup"     "$out" "tab rename w1:t3 nightly-ETL-job-drops-rows"
+check_rename   "a title needs no process lookup"     "$out" w1:t3 "nightly-ETL-job-drops-rows"
 teardown
 
 # ----------------------------------------------------------------------
@@ -231,7 +254,7 @@ fixture panes.json <<'JSON'
 ]}}
 JSON
 out=$(run_event tab.created >/dev/null 2>&1; log)
-check_contains "off by default: the sentence survives" "$out" "tab rename w1:t1 Squash merge command"
+check_rename   "off by default: the sentence survives" "$out" w1:t1 "Squash merge command"
 teardown
 
 # ----------------------------------------------------------------------
@@ -255,9 +278,11 @@ fixture panes.json <<'JSON'
 ]}}
 JSON
 out=$(run_event tab.created >/dev/null 2>&1; log)
-# Two fewer characters than the glyphless label above: "drops-rows" no longer fits.
-check_contains "the glyph is reserved out of the budget" "$out" "nightly-ETL-job-drops"
-check_absent   "so nothing is cut off the end"           "$out" "drops-row "
+# The glyph and its space bring the label to exactly the 28 available, so nothing
+# is dropped: an earlier comment here claimed "drops-rows" no longer fitted, which
+# was arithmetic that did not hold. Asserted whole, so a label short by any amount
+# fails rather than passing on a prefix.
+check_rename "the glyph is reserved out of the budget" "$out" w1:t1 "$(printf '\363\260\232\251') nightly-ETL-job-drops-rows"
 teardown
 
 # ----------------------------------------------------------------------
@@ -300,11 +325,8 @@ out=$(run_event tab.created >/dev/null 2>&1; log)
 # reserving two would have condensed to 26 and left ar_format to cut "many" in
 # half. The whole label is asserted, not a prefix of it: a substring check here
 # passes on any longer cut and proves nothing about where the budget landed.
-check_contains "a wide glyph is reserved whole"  "$out" "tab rename w1:t1 XYZZ nightly-ETL-job-drops"
-# Anchored to the tab: the log carries every rename, and t2 legitimately ends in
-# "drops-many", so a bare needle matches the correct label on the other tab.
-check_absent   "and the word after it is gone"   "$out" "w1:t1 XYZZ nightly-ETL-job-drops-man"
-check_contains "no glyph reserves nothing"       "$out" "tab rename w1:t2 nightly-ETL-job-drops-many"
+check_rename   "a wide glyph is reserved whole"  "$out" w1:t1 "XYZZ nightly-ETL-job-drops"
+check_rename   "no glyph reserves nothing"       "$out" w1:t2 "nightly-ETL-job-drops-many"
 teardown
 
 # ----------------------------------------------------------------------
@@ -337,9 +359,9 @@ fixture panes.json <<'JSON'
 ]}}
 JSON
 out=$(run_event tab.created >/dev/null 2>&1; log)
-check_contains "a configured brand comes off"    "$out" "tab rename w1:t1 reviewing-unpushed-commits"
+check_rename   "a configured brand comes off"    "$out" w1:t1 "reviewing-unpushed-commits"
 check_absent   "and does not reach the tab"      "$out" "OC-reviewing"
-check_contains "another agent keeps those chars" "$out" "tab rename w1:t2 API-authentication-migration"
+check_rename   "another agent keeps those chars" "$out" w1:t2 "API-authentication-migration"
 teardown
 
 # ----------------------------------------------------------------------
@@ -363,7 +385,7 @@ fixture panes.json <<'JSON'
 ]}}
 JSON
 out=$(run_event tab.created >/dev/null 2>&1; log)
-check_contains "unconfigured, the badge stays"   "$out" "tab rename w1:t1 OC-reviewing-unpushed"
+check_rename   "unconfigured, the badge stays"   "$out" w1:t1 "OC-reviewing-unpushed"
 teardown
 
 t_summary


### PR DESCRIPTION
@qu8n [You mentioned liking](https://github.com/qu8n/herdr-automatic-rename/pull/10#issuecomment-5447549877) the condensed `nightly-ETL-job-drops-rows` label in #10. This is that, rebuilt on `v0.8.0` as an opt-in layer rather than the composition model that PR carried.

`AGENT_TITLES` puts the agent's sentence on the tab and `MAX_TITLE_LEN` takes the end off it, which is where the words saying *which* task this is tend to sit:

| The agent reports | Today | `TITLE_CONDENSE=1` |
| --- | --- | --- |
| Investigate why the nightly ETL job drops rows | `Investigate why the nightly` | `nightly-ETL-job-drops-rows` |
| Adjust the screensaver timeout | `Adjust the screensaver` | `screensaver-timeout` |
| Review RFC7 wording for clarity | `Review RFC7 wording for` | `RFC7-wording-clarity` |

It selects and never generates: the words are the agent's own, in the order it wrote them, on the reasoning that it put the salient ones first. Scoring for distinctness instead was tried and reads worse, preferring where the work happens over what it is. A title it cannot shorten is left as the sentence, so no tab loses a label it had.

## Off by default, and that is load-bearing

`TITLE_CONDENSE=0` is the default, so a config that does not name it renders exactly what `AGENT_TITLES` renders today. That is also what keeps the diff a bolt-on: **every released expectation still describes shipped behaviour**, and the new checks sit in their own file, so neither has to be re-resolved when the title path changes.

The engine change is one call between `ar_title_clean` and `ar_format`. Both title sources go through it, so a topic read from a transcript is condensed the same way a terminal title is.

## The word lists are measured, not imagined

The corpus is the last title Claude Code generated in each of 65 titled sessions on one machine over three weeks, which is the title the engine itself reads (`transcript.sh` takes `last(inputs)`). The other 1735 transcripts there are subagent runs and headless `sdk-cli` invocations, which are never titled.

The list fires on 35 of the 65, and 30 of those get a content word back inside the same budget. No two *different* titles among the 65 condense to the same label with the rule on or off, so the drop buys information without costing distinctness. `analyze` was the most frequent opener a first hand-written list had missed.

Its limits are in the comments rather than left to be discovered. The list matches spelling and not part of speech, so "Review flashcard generation" and "Implement flashcard generation" reduce alike; that did not occur across the 65, but one person and one agent is not a corpus, which is the argument for a knob. An all-caps token is treated as an identifier and spared from the filler list, so `Investigate IT outage` keeps its `IT` -- listing a word in capitals drops it again, shouted prose keeps its capitals, and a one-letter identifier is not covered.

## Budget

A condensed label is charged to `MAX_TITLE_LEN` like any other, and the glyph and its space are reserved out of it first, since `ar_format` prepends them before truncating. The reserve is the actual glyph rather than an allowance for one: an `ICON_MAP` entry may be any string, and reserving a flat two characters cut a word in half at the end, which is the one thing condensing exists to prevent.

## Knobs

`TITLE_CONDENSE`, `TITLE_LEAD_VERBS`, `TITLE_FILLER_WORDS`, `TITLE_WORD_SEPARATOR`, `TITLE_CASE`. No new length knob: the budget is `MAX_TITLE_LEN`, so the two cannot disagree.

## Tests

46 in `tests/test_condense.sh`, unit and end-to-end against the fake herdr. Assertions compare a whole label rather than a substring, and each was checked by mutating the implementation to confirm it fails. `./tests/run.sh` passes, `make lint-sh` clean.
